### PR TITLE
Improve error  callback

### DIFF
--- a/examples/hello_c/hello_c.c
+++ b/examples/hello_c/hello_c.c
@@ -55,7 +55,7 @@ the response is represented inside the () :
 Error error;
 
 // Function pointers used to get the return from rust lib
-static void error_cb(const uint8_t *p, int len) {
+static void error_cb(const uint8_t *p, int len, void *) {
     if (error.ptr != NULL) {
         free((void *)error.ptr);
     }
@@ -65,6 +65,8 @@ static void error_cb(const uint8_t *p, int len) {
 }
 
 int main(void) {
+    RetError ret_error;
+    ret_error.call = error_cb;
 
     // Canister info from hello world deploy example
     const char *id_text = "rrkah-fqaaa-aaaaa-aaaaq-cai";
@@ -78,7 +80,7 @@ int main(void) {
     get_did_file_content(did_file, file_size, did_content);
 
     // Compute principal id from text
-    CPrincipal *principal = principal_from_text(id_text,error_cb);
+    CPrincipal *principal = principal_from_text(id_text,&ret_error);
     CHECK_ERROR(error);
 
     //compute id
@@ -87,17 +89,17 @@ int main(void) {
 
     // Create an IDLArg argument from a IDLValue
     const char * arg1 = "world";
-    IDLValue *element_1 = idl_value_with_text(arg1, error_cb);
+    IDLValue *element_1 = idl_value_with_text(arg1, &ret_error);
     CHECK_ERROR(error);
     const IDLValue* elems[] = {element_1};
     IDLArgs *idl_args_ptr_1 = idl_args_from_vec(elems, 1);
 
     // Create Agent 1
-    FFIAgent *agent_1 = agent_create(url, &id, principal, did_content, error_cb);
+    FFIAgent *agent_1 = agent_create(url, &id, principal, did_content, &ret_error);
     CHECK_ERROR(error);
 
     // Send query call to agent 1
-    IDLArgs *call_1 = agent_query(agent_1, method, idl_args_ptr_1, error_cb);
+    IDLArgs *call_1 = agent_query(agent_1, method, idl_args_ptr_1, &ret_error);
     CHECK_ERROR(error);
 
     //Translate IdlArg to text
@@ -105,17 +107,17 @@ int main(void) {
 
     // Create an IDLArg argument from a IDLValue
     const char * arg2 = "zondax";
-    IDLValue *element_2 = idl_value_with_text(arg2, error_cb);
+    IDLValue *element_2 = idl_value_with_text(arg2, &ret_error);
     CHECK_ERROR(error);
     const IDLValue* elems2[] = {element_2};
     IDLArgs* idl_args_ptr_2 = idl_args_from_vec(elems2, 1);
 
     // Create Agent 2
-    FFIAgent *agent_2 = agent_create(url, &id, principal, did_content, error_cb);
+    FFIAgent *agent_2 = agent_create(url, &id, principal, did_content, &ret_error);
     CHECK_ERROR(error);
 
     // Send query call to agent 2
-    IDLArgs *call_2 = agent_query(agent_2, method, idl_args_ptr_2, error_cb);
+    IDLArgs *call_2 = agent_query(agent_2, method, idl_args_ptr_2, &ret_error);
     CHECK_ERROR(error);
 
     //Translate IdlArg to text

--- a/examples/ic_c/ic_c.c
+++ b/examples/ic_c/ic_c.c
@@ -33,7 +33,7 @@ CIdentity id_anonym;
 CIdentity id_secp26k1;
 
 // Function pointers used to get the return from rust lib
-static void error_cb(const uint8_t *p, int len) {
+static void error_cb(const uint8_t *p, int len, void *) {
     if (error.ptr != NULL) {
         free((void *)error.ptr);
     }
@@ -43,6 +43,9 @@ static void error_cb(const uint8_t *p, int len) {
 }
 
 int main(void) {
+    RetError ret_error;
+    ret_error.call = error_cb;
+
     // Canister info from hello world deploy example
     const char *id_text = "rdmx6-jaaaa-aaaaa-aaadq-cai";
     const char *did_file = "../examples/icp-app/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
@@ -54,7 +57,7 @@ int main(void) {
     get_did_file_content(did_file, file_size, did_content);
 
     // Compute principal id from text
-    CPrincipal *principal = principal_from_text(id_text,error_cb);
+    CPrincipal *principal = principal_from_text(id_text,&ret_error);
     CHECK_ERROR(error);
 
     //compute id
@@ -62,7 +65,7 @@ int main(void) {
     anonymous_identity(&id);
 
     // Create Agent 1
-    FFIAgent *agent_1 = agent_create(url, &id_anonym, principal, did_content, error_cb);
+    FFIAgent *agent_1 = agent_create(url, &id_anonym, principal, did_content, &ret_error);
     CHECK_ERROR(error);
     
     // Create IDL argument
@@ -71,7 +74,7 @@ int main(void) {
     IDLArgs* idl_args_ptr = idl_args_from_vec(elems, 1);
 
     // IDL Args
-    IDLArgs *call_1 = agent_query(agent_1, "lookup", idl_args_ptr,error_cb);
+    IDLArgs *call_1 = agent_query(agent_1, "lookup", idl_args_ptr,&ret_error);
     CHECK_ERROR(error);
 
     // Print arg in text

--- a/examples/principal_c/principal_c.c
+++ b/examples/principal_c/principal_c.c
@@ -25,7 +25,7 @@
 Error error;
 
 // Function pointers used to get the return from rust lib
-static void error_cb(const uint8_t *p, int len) {
+static void error_cb(const uint8_t *p, int len, void *) {
     if (error.ptr != NULL) {
         free((void *)error.ptr);
     }
@@ -35,6 +35,9 @@ static void error_cb(const uint8_t *p, int len) {
 }
 
 int main(void) {
+    RetError ret_error;
+    ret_error.call = error_cb;
+
     printf("+++++++++ Testing exported Principal Core Functions +++++++++\n");
 
     // Get Principal Management Canister
@@ -107,7 +110,7 @@ int main(void) {
     };
 
     principal_destroy(p);
-    p = principal_try_from_slice(bytes, 32, error_cb);
+    p = principal_try_from_slice(bytes, 32, &ret_error);
     if (error.ptr != NULL) {
         printf(" Test 4.1: Error is expected : %s\n", error.ptr);
     } else {
@@ -118,7 +121,7 @@ int main(void) {
     const char *text = "2vxsx-fae";
     
     principal_destroy(p);
-    p = principal_from_text(text, error_cb);
+    p = principal_from_text(text, &ret_error);
     
     if (p->len == 1 && p->ptr[0] == 4) {
         printf(" Test 5: Valid Principal from text.\n");
@@ -130,7 +133,7 @@ int main(void) {
     unsigned char principal[] = { 4 };
 
     principal_destroy(p);
-    p = principal_to_text(principal, 1, error_cb);
+    p = principal_to_text(principal, 1, &ret_error);
     
     if (!strcmp(text, (const char *)p->ptr)) {
         printf(" Test 6: Valid Text from Principal.\n");

--- a/ic-agent-wrapper/bindings.h
+++ b/ic-agent-wrapper/bindings.h
@@ -68,7 +68,12 @@ typedef struct CPrincipal {
 /**
  * CallBack Ptr creation with size and len
  */
-typedef void (*RetPtr_u8)(const uint8_t*, int);
+typedef void (*RetPtr_u8)(const uint8_t*, int, void*);
+
+typedef struct RetError {
+  void *user_data;
+  RetPtr_u8 call;
+} RetError;
 
 /**
  * @brief Free allocated memory
@@ -355,7 +360,7 @@ struct FFIAgent *agent_create_wrap(const char *path,
                                    const uint8_t *canister_id,
                                    int canister_id_len,
                                    const char *did_content,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Calls and returns the information returned by the status endpoint of a replica
@@ -366,7 +371,7 @@ struct FFIAgent *agent_create_wrap(const char *path,
  * If the function returns a NULL CText the user should check
  * The error callback, to attain the error
  */
-struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetPtr_u8 error_ret);
+struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, struct RetError *error_ret);
 
 /**
  * @brief Calls and returns a query call to the canister
@@ -380,7 +385,7 @@ struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetPtr_u8 erro
 IDLArgs *agent_query_wrap(const struct FFIAgent *agent_ptr,
                           const char *method,
                           const char *method_args,
-                          RetPtr_u8 error_ret);
+                          struct RetError *error_ret);
 
 /**
  * @brief Calls and returns a update call to the canister
@@ -396,7 +401,7 @@ IDLArgs *agent_query_wrap(const struct FFIAgent *agent_ptr,
 IDLArgs *agent_update_wrap(const struct FFIAgent *agent_ptr,
                            const char *method,
                            const char *method_args,
-                           RetPtr_u8 error_ret);
+                           struct RetError *error_ret);
 
 /**
  * @brief Free allocated Agent
@@ -424,7 +429,7 @@ struct CText *idl_args_to_text(const IDLArgs *idl_args);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-IDLArgs *idl_args_from_text(const char *text, RetPtr_u8 error_ret);
+IDLArgs *idl_args_from_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Translate IDLArgs to bytes array
@@ -434,7 +439,7 @@ IDLArgs *idl_args_from_text(const char *text, RetPtr_u8 error_ret);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetPtr_u8 error_ret);
+struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, struct RetError *error_ret);
 
 /**
  * @brief Translate IDLArgs from a byte representation
@@ -446,7 +451,7 @@ struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetPtr_u8 error_ret);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-IDLArgs *idl_args_from_bytes(const uint8_t *bytes, int bytes_len, RetPtr_u8 error_ret);
+IDLArgs *idl_args_from_bytes(const uint8_t *bytes, int bytes_len, struct RetError *error_ret);
 
 /**
  * @brief Create IDLArgs from an IDLValue Array(C)/Vector(Rust)
@@ -477,7 +482,7 @@ void idl_args_destroy(IDLArgs *_ptr);
 /**
  * Format Text to IDLValue text format
  */
-IDLValue *idl_value_format_text(const char *text, RetPtr_u8 error_ret);
+IDLValue *idl_value_format_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Test if IDLValues are equal
@@ -497,7 +502,7 @@ bool idl_value_is_equal(const IDLValue *idl_1, const IDLValue *idl_2);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_nat(const char *nat, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_nat(const char *nat, struct RetError *error_ret);
 
 /**
  * @brief Create IDLValue with nat8
@@ -720,7 +725,7 @@ IDLValue *idl_value_with_none(void);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_text(const char *text, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Get Text from IDLValue
@@ -742,7 +747,7 @@ struct CText *text_from_idl_value(const IDLValue *ptr);
  */
 IDLValue *idl_value_with_principal(const uint8_t *principal,
                                    int principal_len,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Principal from IDLValue
@@ -762,7 +767,9 @@ struct CPrincipal *principal_from_idl_value(const IDLValue *ptr);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_service(const uint8_t *principal, int principal_len, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_service(const uint8_t *principal,
+                                 int principal_len,
+                                 struct RetError *error_ret);
 
 /**
  * @brief Service from IDLValue
@@ -781,7 +788,7 @@ struct CPrincipal *service_from_idl_value(const IDLValue *ptr);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_number(const char *number, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_number(const char *number, struct RetError *error_ret);
 
 /**
  * @brief Get Number from IDLValue
@@ -915,7 +922,7 @@ void *identity_anonymous(void);
  * If the function returns a NULL pointer the user should check
  * The error callback, to attain the error
  */
-void *identity_basic_from_pem(const char *pem_data, RetPtr_u8 error_ret);
+void *identity_basic_from_pem(const char *pem_data, struct RetError *error_ret);
 
 /**
  * @brief Create a BasicIdentity from a KeyPair from the ring crate
@@ -931,7 +938,7 @@ void *identity_basic_from_pem(const char *pem_data, RetPtr_u8 error_ret);
  */
 void *identity_basic_from_key_pair(const uint8_t *public_key,
                                    const uint8_t *private_key_seed,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Creates an Secp256k1 identity from a PEM file
@@ -944,7 +951,7 @@ void *identity_basic_from_key_pair(const uint8_t *public_key,
  * If the function returns a NULL pointer the user should check
  * The error callback, to attain the error
  */
-void *identity_secp256k1_from_pem(const char *pem_data, RetPtr_u8 error_ret);
+void *identity_secp256k1_from_pem(const char *pem_data, struct RetError *error_ret);
 
 /**
  * @brief Create a Secp256k1 from a KeyPair from the ring crate
@@ -970,7 +977,7 @@ void *identity_secp256k1_from_private_key(const char *private_key, uintptr_t pk_
  */
 struct CPrincipal *identity_sender(void *id_ptr,
                                    enum IdentityType idType,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Sign a blob, the concatenation of the domain separator & request ID,
@@ -989,7 +996,7 @@ struct CIdentitySign *identity_sign(const uint8_t *bytes,
                                     int bytes_len,
                                     void *id_ptr,
                                     enum IdentityType idType,
-                                    RetPtr_u8 error_ret);
+                                    struct RetError *error_ret);
 
 /**
  * @brief Construct a Principal of the IC management canister
@@ -1035,7 +1042,7 @@ struct CPrincipal *principal_from_slice(const uint8_t *bytes, int bytes_len);
  */
 struct CPrincipal *principal_try_from_slice(const uint8_t *bytes,
                                             int bytes_len,
-                                            RetPtr_u8 error_ret);
+                                            struct RetError *error_ret);
 
 /**
  * @brief Construct a Principal from text representation.
@@ -1046,7 +1053,7 @@ struct CPrincipal *principal_try_from_slice(const uint8_t *bytes,
  * If the function returns a NULL CPrincipal the user should check
  * The error callback, to attain the error
  */
-struct CPrincipal *principal_from_text(const char *text, RetPtr_u8 error_ret);
+struct CPrincipal *principal_from_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Return the textual representation of Principal.
@@ -1058,7 +1065,9 @@ struct CPrincipal *principal_from_text(const char *text, RetPtr_u8 error_ret);
  * If the function returns a NULL CPrincipal the user should check
  * The error callback, to attain the error
  */
-struct CPrincipal *principal_to_text(const uint8_t *bytes, int bytes_len, RetPtr_u8 error_ret);
+struct CPrincipal *principal_to_text(const uint8_t *bytes,
+                                     int bytes_len,
+                                     struct RetError *error_ret);
 
 /**
  * @brief Free allocated Memory

--- a/ic-agent-wrapper/src/candid/mod.rs
+++ b/ic-agent-wrapper/src/candid/mod.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use crate::{
-    principal::CPrincipal, AnyErr, CBytes, CFunc, CIDLValuesVec, CRecord, CText, CVariant, RetPtr,
+    principal::CPrincipal, AnyErr, CBytes, CFunc, CIDLValuesVec, CRecord, CText, CVariant, RetError,
 };
 
 /*******************************************************************************
@@ -57,7 +57,7 @@ pub extern "C" fn idl_args_to_text(idl_args: &IDLArgs) -> Option<Box<CText>> {
 #[no_mangle]
 pub extern "C" fn idl_args_from_text(
     text: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLArgs>> {
     let text = unsafe { CStr::from_ptr(text).to_str().map_err(AnyErr::from) };
 
@@ -71,7 +71,9 @@ pub extern "C" fn idl_args_from_text(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -86,7 +88,7 @@ pub extern "C" fn idl_args_from_text(
 #[no_mangle]
 pub extern "C" fn idl_args_to_bytes(
     idl_args: &IDLArgs,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError >,
 ) -> Option<Box<CBytes>> {
     let idl_bytes = idl_args.to_bytes();
 
@@ -98,7 +100,9 @@ pub extern "C" fn idl_args_to_bytes(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -116,7 +120,7 @@ pub extern "C" fn idl_args_to_bytes(
 pub extern "C" fn idl_args_from_bytes(
     bytes: *const u8,
     bytes_len: c_int,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError >,
 ) -> Option<Box<IDLArgs>> {
     let slice = unsafe { std::slice::from_raw_parts(bytes, bytes_len as usize) };
 
@@ -130,7 +134,9 @@ pub extern "C" fn idl_args_from_bytes(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -202,7 +208,7 @@ pub extern "C" fn idl_args_destroy(_ptr: Option<Box<IDLArgs>>) {}
 #[no_mangle]
 pub extern "C" fn idl_value_format_text(
     text: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLValue>> {
     let text = unsafe { CStr::from_ptr(text).to_str().map_err(AnyErr::from) }.ok()?;
 
@@ -223,7 +229,9 @@ pub extern "C" fn idl_value_format_text(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -249,7 +257,7 @@ pub extern "C" fn idl_value_is_equal(idl_1: &IDLValue, idl_2: &IDLValue) -> bool
 #[no_mangle]
 pub extern "C" fn idl_value_with_nat(
     nat: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLValue>> {
     let result = unsafe { CStr::from_ptr(nat).to_str().map_err(AnyErr::from) }
         .and_then(|nat| Nat::from_str(nat).map_err(AnyErr::from))
@@ -263,7 +271,9 @@ pub extern "C" fn idl_value_with_nat(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -617,7 +627,7 @@ pub extern "C" fn idl_value_with_none() -> Box<IDLValue> {
 #[no_mangle]
 pub extern "C" fn idl_value_with_text(
     text: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLValue>> {
     let text = unsafe { CStr::from_ptr(text).to_str().map_err(AnyErr::from) };
 
@@ -630,7 +640,9 @@ pub extern "C" fn idl_value_with_text(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -666,7 +678,7 @@ pub extern "C" fn text_from_idl_value(ptr: &IDLValue) -> Option<Box<CText>> {
 pub extern "C" fn idl_value_with_principal(
     principal: *const u8,
     principal_len: c_int,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLValue>> {
     let slice = unsafe { std::slice::from_raw_parts(principal, principal_len as usize) };
 
@@ -680,7 +692,9 @@ pub extern "C" fn idl_value_with_principal(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -719,7 +733,7 @@ pub extern "C" fn principal_from_idl_value(ptr: &IDLValue) -> Option<Box<CPrinci
 pub extern "C" fn idl_value_with_service(
     principal: *const u8,
     principal_len: c_int,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLValue>> {
     let slice = unsafe { std::slice::from_raw_parts(principal, principal_len as usize) };
 
@@ -733,7 +747,9 @@ pub extern "C" fn idl_value_with_service(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
             None
         }
     }
@@ -767,7 +783,7 @@ pub extern "C" fn service_from_idl_value(ptr: &IDLValue) -> Option<Box<CPrincipa
 #[no_mangle]
 pub extern "C" fn idl_value_with_number(
     number: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLValue>> {
     let number = unsafe { CStr::from_ptr(number).to_str().map_err(AnyErr::from) };
 
@@ -781,7 +797,9 @@ pub extern "C" fn idl_value_with_number(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
 
             None
         }
@@ -1111,8 +1129,6 @@ mod tests {
         68, 73, 68, 76, 0, 3, 126, 104, 117, 1, 1, 1, 4, 244, 255, 255, 255,
     ];
 
-    extern "C" fn error_ret(_data: *const u8, _len: c_int) {}
-
     fn create_value_list() -> Vec<IDLValue> {
         vec![
             IDLValue::Bool(true),
@@ -1134,7 +1150,8 @@ mod tests {
 
     #[test]
     fn idl_args_from_text_test() {
-        let result = idl_args_from_text(IDL_ARGS_TEXT_C.as_ptr() as *const c_char, error_ret);
+
+        let result = idl_args_from_text(IDL_ARGS_TEXT_C.as_ptr() as *const c_char, None);
         let result = result.unwrap();
         assert_eq!(IDLArgs::new(&IDL_VALUES), *result);
     }
@@ -1142,17 +1159,17 @@ mod tests {
     #[test]
     fn idl_args_to_bytes_test() {
         let idl_args = IDLArgs::new(&IDL_VALUES);
-
-        let result = idl_args_to_bytes(&idl_args, error_ret).unwrap();
+        let result = idl_args_to_bytes(&idl_args, None).unwrap();
         assert_eq!(IDL_ARGS_BYTES, result.data);
     }
 
     #[test]
     fn idl_args_from_bytes_test() {
+
         let result = idl_args_from_bytes(
             IDL_ARGS_BYTES.as_ptr(),
             IDL_ARGS_BYTES.len() as c_int,
-            error_ret,
+            None,
         );
         let result = result.unwrap();
         assert_eq!(IDLArgs::new(&IDL_VALUES), *result);
@@ -1160,10 +1177,11 @@ mod tests {
 
     #[test]
     fn idl_args_from_vec_test() {
+
         let result = idl_args_from_bytes(
             IDL_ARGS_BYTES.as_ptr(),
             IDL_ARGS_BYTES.len() as c_int,
-            error_ret,
+            None,
         );
         let result = result.unwrap();
         assert_eq!(IDLArgs::new(&IDL_VALUES), *result);
@@ -1190,7 +1208,7 @@ mod tests {
         const NAT: &str = "98989898989898989898";
         const C_NAT: *const c_char = b"98989898989898989898\0".as_ptr() as *const c_char;
 
-        let result = idl_value_with_nat(C_NAT, error_ret);
+        let result = idl_value_with_nat(C_NAT, None);
         let result = result.unwrap();
         assert_eq!(IDLValue::Nat(Nat::from_str(NAT).unwrap()), *result);
     }
@@ -1277,7 +1295,7 @@ mod tests {
     fn idl_value_with_number_test() {
         const NUMBER: &[u8] = b"1234567890\0";
 
-        let result = idl_value_with_number(NUMBER.as_ptr() as *const c_char, error_ret);
+        let result = idl_value_with_number(NUMBER.as_ptr() as *const c_char, None);
         let result = result.unwrap();
         assert_eq!(IDLValue::Number("1234567890".to_string()), *result);
     }
@@ -1303,7 +1321,7 @@ mod tests {
     fn idl_value_with_text_test() {
         const BTEXT: &[u8] = b"Hello World\0";
 
-        let result = idl_value_with_text(BTEXT.as_ptr() as *const c_char, error_ret);
+        let result = idl_value_with_text(BTEXT.as_ptr() as *const c_char, None);
         let result = result.unwrap();
         assert_eq!(&IDLValue::Text("Hello World".to_string()), result.deref());
     }

--- a/ic-agent-wrapper/src/identity/mod.rs
+++ b/ic-agent-wrapper/src/identity/mod.rs
@@ -15,7 +15,7 @@
 ********************************************************************************/
 #![allow(non_snake_case)]
 
-use crate::{principal::CPrincipal, AnyErr, CIdentitySign, RetPtr};
+use crate::{principal::CPrincipal, AnyErr, CIdentitySign, RetError};
 use cty::c_int;
 use ic_agent::{
     identity::{AnonymousIdentity, BasicIdentity, Secp256k1Identity},
@@ -60,7 +60,7 @@ pub extern "C" fn identity_anonymous() -> *mut c_void {
 #[no_mangle]
 pub extern "C" fn identity_basic_from_pem(
     pem_data: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> *mut c_void {
     let pem_cstr = unsafe {
         assert!(!pem_data.is_null());
@@ -78,7 +78,9 @@ pub extern "C" fn identity_basic_from_pem(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
 
             std::ptr::null_mut()
         }
@@ -99,7 +101,7 @@ pub extern "C" fn identity_basic_from_pem(
 pub extern "C" fn identity_basic_from_key_pair(
     public_key: *const u8,
     private_key_seed: *const u8,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> *mut c_void {
     let public_key_slice = unsafe { std::slice::from_raw_parts(public_key as *const u8, 32) };
     let private_key_seed_slice =
@@ -116,7 +118,9 @@ pub extern "C" fn identity_basic_from_key_pair(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
 
             std::ptr::null_mut()
         }
@@ -135,7 +139,7 @@ pub extern "C" fn identity_basic_from_key_pair(
 #[no_mangle]
 pub extern "C" fn identity_secp256k1_from_pem(
     pem_data: *const c_char,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> *mut c_void {
     let pem_cstr = unsafe {
         assert!(!pem_data.is_null());
@@ -153,7 +157,9 @@ pub extern "C" fn identity_secp256k1_from_pem(
                 let fallback_error = "Failed to convert error message to CString";
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
-            error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+            if let Some(error_ret) = error_ret {
+                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+            }
 
             std::ptr::null_mut()
         }
@@ -192,7 +198,7 @@ pub extern "C" fn identity_secp256k1_from_private_key(
 pub extern "C" fn identity_sender(
     id_ptr: *mut c_void,
     idType: IdentityType,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<CPrincipal>> {
     unsafe {
         match idType {
@@ -213,7 +219,9 @@ pub extern "C" fn identity_sender(
                             let fallback_error = "Failed to convert error message to CString";
                             CString::new(fallback_error).expect("Fallback error message is invalid")
                         });
-                        error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+                        if let Some(error_ret) = error_ret {
+                            (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                        }
                         None
                     }
                 }
@@ -235,7 +243,9 @@ pub extern "C" fn identity_sender(
                             let fallback_error = "Failed to convert error message to CString";
                             CString::new(fallback_error).expect("Fallback error message is invalid")
                         });
-                        error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+                        if let Some(error_ret) = error_ret {
+                            (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                        }
                         None
                     }
                 }
@@ -257,7 +267,9 @@ pub extern "C" fn identity_sender(
                             let fallback_error = "Failed to convert error message to CString";
                             CString::new(fallback_error).expect("Fallback error message is invalid")
                         });
-                        error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+                        if let Some(error_ret) = error_ret {
+                            (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                        }
                         None
                     }
                 }
@@ -283,7 +295,7 @@ pub extern "C" fn identity_sign(
     bytes_len: c_int,
     id_ptr: *mut c_void,
     idType: IdentityType,
-    error_ret: RetPtr<u8>,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<CIdentitySign>> {
     unsafe {
         match idType {
@@ -310,7 +322,9 @@ pub extern "C" fn identity_sign(
                             let fallback_error = "Failed to convert error message to CString";
                             CString::new(fallback_error).expect("Fallback error message is invalid")
                         });
-                        error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+                        if let Some(error_ret) = error_ret {
+                            (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                        }
 
                         None
                     }
@@ -339,7 +353,9 @@ pub extern "C" fn identity_sign(
                             let fallback_error = "Failed to convert error message to CString";
                             CString::new(fallback_error).expect("Fallback error message is invalid")
                         });
-                        error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+                        if let Some(error_ret) = error_ret {
+                            (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                        }
 
                         None
                     }
@@ -368,7 +384,9 @@ pub extern "C" fn identity_sign(
                             let fallback_error = "Failed to convert error message to CString";
                             CString::new(fallback_error).expect("Fallback error message is invalid")
                         });
-                        error_ret(c_string.as_ptr() as _, c_string.as_bytes().len() as _);
+                        if let Some(error_ret) = error_ret {
+                            (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                        }
 
                         None
                     }
@@ -399,8 +417,6 @@ oUQDQgAEgO87rJ1ozzdMvJyZQ+GABDqUxGLvgnAnTlcInV3NuhuPv4O3VGzMGzeB
 N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
 -----END EC PRIVATE KEY-----\0";
 
-    extern "C" fn error_ret(_data: *const u8, _len: c_int) {}
-
     #[test]
     fn test_identity_anonymous() {
         let identity = identity_anonymous();
@@ -421,7 +437,7 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
             assert_eq!(boxed.sender(), Ok(Principal::anonymous()));
         }
 
-        let principal = identity_sender(identity, IdentityType::Anonym, error_ret);
+        let principal = identity_sender(identity, IdentityType::Anonym, None);
         let principal = principal.unwrap();
         let slice = unsafe { std::slice::from_raw_parts(principal.ptr, principal.len as usize) };
 
@@ -430,7 +446,7 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
 
     #[test]
     fn test_identity_basic_from_pem() {
-        let id = identity_basic_from_pem(BASIC_ID_FILE.as_ptr() as *const c_char, error_ret);
+        let id = identity_basic_from_pem(BASIC_ID_FILE.as_ptr() as *const c_char, None);
         assert!(!id.is_null());
 
         unsafe {
@@ -443,7 +459,7 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
     #[test]
     fn test_identity_secp256k1_from_pem() {
         let id =
-            identity_secp256k1_from_pem(SECP256K1_ID_FILE.as_ptr() as *const c_char, error_ret);
+            identity_secp256k1_from_pem(SECP256K1_ID_FILE.as_ptr() as *const c_char, None);
 
         unsafe {
             let boxed = Box::from_raw(id as *mut Secp256k1Identity);
@@ -477,7 +493,7 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
             EMPTY_BYTES.len() as c_int,
             fptr as *mut c_void,
             IdentityType::Basic,
-            error_ret,
+            None,
         );
 
         let result = result.unwrap();

--- a/ic-agent-wrapper/src/lib.rs
+++ b/ic-agent-wrapper/src/lib.rs
@@ -17,6 +17,7 @@ use ::candid::parser::value::IDLValue;
 use ::candid::Principal;
 use anyhow::Error as AnyErr;
 use anyhow::Result as AnyResult;
+use libc::c_void;
 use principal::CPrincipal;
 use std::ffi::c_char;
 use std::ffi::c_int;
@@ -28,7 +29,13 @@ mod principal;
 mod request_id;
 
 /// CallBack Ptr creation with size and len
-type RetPtr<T> = extern "C" fn(*const T, c_int);
+type RetPtr<T> = extern "C" fn(*const T, c_int, *mut c_void);
+
+#[repr(C)]
+pub struct RetError {
+    user_data: *mut c_void,
+    call: RetPtr<u8>,
+}
 
 /// @brief Free allocated memory
 ///

--- a/lib-agent-c/inc/agent_c.h
+++ b/lib-agent-c/inc/agent_c.h
@@ -35,7 +35,7 @@ extern "C" {
  * @return FFIAgent pointer 
  */
 FFIAgent *agent_create(const char *url, CIdentity *id, CPrincipal *canister,
-                const char *did_content, RetPtr_u8 error_cb);
+                const char *did_content, RetError *error_cb);
 
 /**
  * @brief Calls and returns the information returned by the status endpoint of a replica
@@ -44,7 +44,7 @@ FFIAgent *agent_create(const char *url, CIdentity *id, CPrincipal *canister,
  * @param error_cb returned error
  * @return agent call result
  */
-CText* agent_status(const struct FFIAgent *agent, RetPtr_u8 error_cb);
+CText* agent_status(const struct FFIAgent *agent, RetError *error_cb);
 
 /**
  * @brief Update call
@@ -56,7 +56,7 @@ CText* agent_status(const struct FFIAgent *agent, RetPtr_u8 error_cb);
  * @return agent call result
  */
 IDLArgs *agent_update(const struct FFIAgent *agent, const char *method,
-                IDLArgs *method_args, RetPtr_u8 error_cb);
+                IDLArgs *method_args, RetError *error_cb);
 
 /**
  * @brief Query call
@@ -68,7 +68,7 @@ IDLArgs *agent_update(const struct FFIAgent *agent, const char *method,
  * @return agent call result
  */
 IDLArgs *agent_query(const struct FFIAgent *agent, const char *method,
-                IDLArgs *method_args, RetPtr_u8 error_cb);
+                IDLArgs *method_args, RetError *error_cb);
 
 #ifdef __cplusplus
 }

--- a/lib-agent-c/inc/identity_c.h
+++ b/lib-agent-c/inc/identity_c.h
@@ -39,7 +39,7 @@ void anonymous_identity(CIdentity *id);
  * @param error_cb returned error
  */
 void basic_identity_from_pem(const char *pem_data, CIdentity *id,
-                             RetPtr_u8 error);
+                             RetError *error);
 
 /**
  * @brief Get Basic Identity from pair of keys
@@ -51,7 +51,7 @@ void basic_identity_from_pem(const char *pem_data, CIdentity *id,
  */
 void basic_identity_from_key_pair(const uint8_t *public_key,
                                   const uint8_t *private_key_seed, CIdentity *id,
-                                  RetPtr_u8 error_ret);
+                                  RetError *error_ret);
 
 /**
  * @brief Get Secp256k1 identity using data from PEM file
@@ -61,7 +61,7 @@ void basic_identity_from_key_pair(const uint8_t *public_key,
  * @param error_cb returned error
  */
 void secp256k1_identity_from_pem(const char *pem_data, CIdentity *id,
-                                 RetPtr_u8 error);
+                                 RetError *error);
 
 /**
  * @brief Get Secp256k1 identity from private key

--- a/lib-agent-c/inc/zondax_ic.h
+++ b/lib-agent-c/inc/zondax_ic.h
@@ -68,7 +68,12 @@ typedef struct CPrincipal {
 /**
  * CallBack Ptr creation with size and len
  */
-typedef void (*RetPtr_u8)(const uint8_t*, int);
+typedef void (*RetPtr_u8)(const uint8_t*, int, void*);
+
+typedef struct RetError {
+  void *user_data;
+  RetPtr_u8 call;
+} RetError;
 
 /**
  * @brief Free allocated memory
@@ -355,7 +360,7 @@ struct FFIAgent *agent_create_wrap(const char *path,
                                    const uint8_t *canister_id,
                                    int canister_id_len,
                                    const char *did_content,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Calls and returns the information returned by the status endpoint of a replica
@@ -366,7 +371,7 @@ struct FFIAgent *agent_create_wrap(const char *path,
  * If the function returns a NULL CText the user should check
  * The error callback, to attain the error
  */
-struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetPtr_u8 error_ret);
+struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, struct RetError *error_ret);
 
 /**
  * @brief Calls and returns a query call to the canister
@@ -380,7 +385,7 @@ struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetPtr_u8 erro
 IDLArgs *agent_query_wrap(const struct FFIAgent *agent_ptr,
                           const char *method,
                           const char *method_args,
-                          RetPtr_u8 error_ret);
+                          struct RetError *error_ret);
 
 /**
  * @brief Calls and returns a update call to the canister
@@ -396,7 +401,7 @@ IDLArgs *agent_query_wrap(const struct FFIAgent *agent_ptr,
 IDLArgs *agent_update_wrap(const struct FFIAgent *agent_ptr,
                            const char *method,
                            const char *method_args,
-                           RetPtr_u8 error_ret);
+                           struct RetError *error_ret);
 
 /**
  * @brief Free allocated Agent
@@ -424,7 +429,7 @@ struct CText *idl_args_to_text(const IDLArgs *idl_args);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-IDLArgs *idl_args_from_text(const char *text, RetPtr_u8 error_ret);
+IDLArgs *idl_args_from_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Translate IDLArgs to bytes array
@@ -434,7 +439,7 @@ IDLArgs *idl_args_from_text(const char *text, RetPtr_u8 error_ret);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetPtr_u8 error_ret);
+struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, struct RetError *error_ret);
 
 /**
  * @brief Translate IDLArgs from a byte representation
@@ -446,7 +451,7 @@ struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetPtr_u8 error_ret);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-IDLArgs *idl_args_from_bytes(const uint8_t *bytes, int bytes_len, RetPtr_u8 error_ret);
+IDLArgs *idl_args_from_bytes(const uint8_t *bytes, int bytes_len, struct RetError *error_ret);
 
 /**
  * @brief Create IDLArgs from an IDLValue Array(C)/Vector(Rust)
@@ -477,7 +482,7 @@ void idl_args_destroy(IDLArgs *_ptr);
 /**
  * Format Text to IDLValue text format
  */
-IDLValue *idl_value_format_text(const char *text, RetPtr_u8 error_ret);
+IDLValue *idl_value_format_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Test if IDLValues are equal
@@ -497,7 +502,7 @@ bool idl_value_is_equal(const IDLValue *idl_1, const IDLValue *idl_2);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_nat(const char *nat, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_nat(const char *nat, struct RetError *error_ret);
 
 /**
  * @brief Create IDLValue with nat8
@@ -720,7 +725,7 @@ IDLValue *idl_value_with_none(void);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_text(const char *text, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Get Text from IDLValue
@@ -742,7 +747,7 @@ struct CText *text_from_idl_value(const IDLValue *ptr);
  */
 IDLValue *idl_value_with_principal(const uint8_t *principal,
                                    int principal_len,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Principal from IDLValue
@@ -762,7 +767,9 @@ struct CPrincipal *principal_from_idl_value(const IDLValue *ptr);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_service(const uint8_t *principal, int principal_len, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_service(const uint8_t *principal,
+                                 int principal_len,
+                                 struct RetError *error_ret);
 
 /**
  * @brief Service from IDLValue
@@ -781,7 +788,7 @@ struct CPrincipal *service_from_idl_value(const IDLValue *ptr);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_number(const char *number, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_number(const char *number, struct RetError *error_ret);
 
 /**
  * @brief Get Number from IDLValue
@@ -915,7 +922,7 @@ void *identity_anonymous(void);
  * If the function returns a NULL pointer the user should check
  * The error callback, to attain the error
  */
-void *identity_basic_from_pem(const char *pem_data, RetPtr_u8 error_ret);
+void *identity_basic_from_pem(const char *pem_data, struct RetError *error_ret);
 
 /**
  * @brief Create a BasicIdentity from a KeyPair from the ring crate
@@ -931,7 +938,7 @@ void *identity_basic_from_pem(const char *pem_data, RetPtr_u8 error_ret);
  */
 void *identity_basic_from_key_pair(const uint8_t *public_key,
                                    const uint8_t *private_key_seed,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Creates an Secp256k1 identity from a PEM file
@@ -944,7 +951,7 @@ void *identity_basic_from_key_pair(const uint8_t *public_key,
  * If the function returns a NULL pointer the user should check
  * The error callback, to attain the error
  */
-void *identity_secp256k1_from_pem(const char *pem_data, RetPtr_u8 error_ret);
+void *identity_secp256k1_from_pem(const char *pem_data, struct RetError *error_ret);
 
 /**
  * @brief Create a Secp256k1 from a KeyPair from the ring crate
@@ -970,7 +977,7 @@ void *identity_secp256k1_from_private_key(const char *private_key, uintptr_t pk_
  */
 struct CPrincipal *identity_sender(void *id_ptr,
                                    enum IdentityType idType,
-                                   RetPtr_u8 error_ret);
+                                   struct RetError *error_ret);
 
 /**
  * @brief Sign a blob, the concatenation of the domain separator & request ID,
@@ -989,7 +996,7 @@ struct CIdentitySign *identity_sign(const uint8_t *bytes,
                                     int bytes_len,
                                     void *id_ptr,
                                     enum IdentityType idType,
-                                    RetPtr_u8 error_ret);
+                                    struct RetError *error_ret);
 
 /**
  * @brief Construct a Principal of the IC management canister
@@ -1035,7 +1042,7 @@ struct CPrincipal *principal_from_slice(const uint8_t *bytes, int bytes_len);
  */
 struct CPrincipal *principal_try_from_slice(const uint8_t *bytes,
                                             int bytes_len,
-                                            RetPtr_u8 error_ret);
+                                            struct RetError *error_ret);
 
 /**
  * @brief Construct a Principal from text representation.
@@ -1046,7 +1053,7 @@ struct CPrincipal *principal_try_from_slice(const uint8_t *bytes,
  * If the function returns a NULL CPrincipal the user should check
  * The error callback, to attain the error
  */
-struct CPrincipal *principal_from_text(const char *text, RetPtr_u8 error_ret);
+struct CPrincipal *principal_from_text(const char *text, struct RetError *error_ret);
 
 /**
  * @brief Return the textual representation of Principal.
@@ -1058,7 +1065,9 @@ struct CPrincipal *principal_from_text(const char *text, RetPtr_u8 error_ret);
  * If the function returns a NULL CPrincipal the user should check
  * The error callback, to attain the error
  */
-struct CPrincipal *principal_to_text(const uint8_t *bytes, int bytes_len, RetPtr_u8 error_ret);
+struct CPrincipal *principal_to_text(const uint8_t *bytes,
+                                     int bytes_len,
+                                     struct RetError *error_ret);
 
 /**
  * @brief Free allocated Memory

--- a/lib-agent-c/inc/zx_ic.h
+++ b/lib-agent-c/inc/zx_ic.h
@@ -68,7 +68,13 @@ typedef struct CPrincipal {
 /**
  * CallBack Ptr creation with size and len
  */
-typedef void (*RetPtr_u8)(const uint8_t*, int);
+typedef void (*RetPtr_u8)(const uint8_t*, int, void *user_data);
+
+typedef struct {
+    void *user_data;
+    RetPtr_u8 *call;
+} RetError;
+
 
 /**
  * @brief Free allocated memory
@@ -355,7 +361,7 @@ struct FFIAgent *agent_create_wrap(const char *path,
                                    const uint8_t *canister_id,
                                    int canister_id_len,
                                    const char *did_content,
-                                   RetPtr_u8 error_ret);
+                                   RetError error_ret);
 
 /**
  * @brief Calls and returns the information returned by the status endpoint of a replica
@@ -366,7 +372,7 @@ struct FFIAgent *agent_create_wrap(const char *path,
  * If the function returns a NULL CText the user should check
  * The error callback, to attain the error
  */
-struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetPtr_u8 error_ret);
+struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetError error_ret);
 
 /**
  * @brief Calls and returns a query call to the canister
@@ -380,7 +386,7 @@ struct CText *agent_status_wrap(const struct FFIAgent *agent_ptr, RetPtr_u8 erro
 IDLArgs *agent_query_wrap(const struct FFIAgent *agent_ptr,
                           const char *method,
                           const char *method_args,
-                          RetPtr_u8 error_ret);
+                          RetError error_ret);
 
 /**
  * @brief Calls and returns a update call to the canister
@@ -396,7 +402,7 @@ IDLArgs *agent_query_wrap(const struct FFIAgent *agent_ptr,
 IDLArgs *agent_update_wrap(const struct FFIAgent *agent_ptr,
                            const char *method,
                            const char *method_args,
-                           RetPtr_u8 error_ret);
+                           RetError error_ret);
 
 /**
  * @brief Free allocated Agent
@@ -424,7 +430,7 @@ struct CText *idl_args_to_text(const IDLArgs *idl_args);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-IDLArgs *idl_args_from_text(const char *text, RetPtr_u8 error_ret);
+IDLArgs *idl_args_from_text(const char *text, RetError error_ret);
 
 /**
  * @brief Translate IDLArgs to bytes array
@@ -434,7 +440,7 @@ IDLArgs *idl_args_from_text(const char *text, RetPtr_u8 error_ret);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetPtr_u8 error_ret);
+struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetError error_ret);
 
 /**
  * @brief Translate IDLArgs from a byte representation
@@ -446,7 +452,7 @@ struct CBytes *idl_args_to_bytes(const IDLArgs *idl_args, RetPtr_u8 error_ret);
  * If the function returns a NULL IDLArgs the user should check
  * The error callback, to attain the error
  */
-IDLArgs *idl_args_from_bytes(const uint8_t *bytes, int bytes_len, RetPtr_u8 error_ret);
+IDLArgs *idl_args_from_bytes(const uint8_t *bytes, int bytes_len, RetError error_ret);
 
 /**
  * @brief Create IDLArgs from an IDLValue Array(C)/Vector(Rust)
@@ -477,7 +483,7 @@ void idl_args_destroy(IDLArgs *_ptr);
 /**
  * Format Text to IDLValue text format
  */
-IDLValue *idl_value_format_text(const char *text, RetPtr_u8 error_ret);
+IDLValue *idl_value_format_text(const char *text, RetError error_ret);
 
 /**
  * @brief Test if IDLValues are equal
@@ -497,7 +503,7 @@ bool idl_value_is_equal(const IDLValue *idl_1, const IDLValue *idl_2);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_nat(const char *nat, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_nat(const char *nat, RetError error_ret);
 
 /**
  * @brief Create IDLValue with nat8
@@ -720,7 +726,7 @@ IDLValue *idl_value_with_none(void);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_text(const char *text, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_text(const char *text, RetError error_ret);
 
 /**
  * @brief Get Text from IDLValue
@@ -742,7 +748,7 @@ struct CText *text_from_idl_value(const IDLValue *ptr);
  */
 IDLValue *idl_value_with_principal(const uint8_t *principal,
                                    int principal_len,
-                                   RetPtr_u8 error_ret);
+                                   RetError error_ret);
 
 /**
  * @brief Principal from IDLValue
@@ -762,7 +768,7 @@ struct CPrincipal *principal_from_idl_value(const IDLValue *ptr);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_service(const uint8_t *principal, int principal_len, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_service(const uint8_t *principal, int principal_len, RetError error_ret);
 
 /**
  * @brief Service from IDLValue
@@ -781,7 +787,7 @@ struct CPrincipal *service_from_idl_value(const IDLValue *ptr);
  * If the function returns a NULL IDLValue the user should check
  * The error callback, to attain the error
  */
-IDLValue *idl_value_with_number(const char *number, RetPtr_u8 error_ret);
+IDLValue *idl_value_with_number(const char *number, RetError error_ret);
 
 /**
  * @brief Get Number from IDLValue
@@ -915,7 +921,7 @@ void *identity_anonymous(void);
  * If the function returns a NULL pointer the user should check
  * The error callback, to attain the error
  */
-void *identity_basic_from_pem(const char *pem_data, RetPtr_u8 error_ret);
+void *identity_basic_from_pem(const char *pem_data, RetError error_ret);
 
 /**
  * @brief Create a BasicIdentity from a KeyPair from the ring crate
@@ -931,7 +937,7 @@ void *identity_basic_from_pem(const char *pem_data, RetPtr_u8 error_ret);
  */
 void *identity_basic_from_key_pair(const uint8_t *public_key,
                                    const uint8_t *private_key_seed,
-                                   RetPtr_u8 error_ret);
+                                   RetError error_ret);
 
 /**
  * @brief Creates an Secp256k1 identity from a PEM file
@@ -944,7 +950,7 @@ void *identity_basic_from_key_pair(const uint8_t *public_key,
  * If the function returns a NULL pointer the user should check
  * The error callback, to attain the error
  */
-void *identity_secp256k1_from_pem(const char *pem_data, RetPtr_u8 error_ret);
+void *identity_secp256k1_from_pem(const char *pem_data, RetError error_ret);
 
 /**
  * @brief Create a Secp256k1 from a KeyPair from the ring crate
@@ -970,7 +976,7 @@ void *identity_secp256k1_from_private_key(const char *private_key, uintptr_t pk_
  */
 struct CPrincipal *identity_sender(void *id_ptr,
                                    enum IdentityType idType,
-                                   RetPtr_u8 error_ret);
+                                   RetError error_ret);
 
 /**
  * @brief Sign a blob, the concatenation of the domain separator & request ID,
@@ -989,7 +995,7 @@ struct CIdentitySign *identity_sign(const uint8_t *bytes,
                                     int bytes_len,
                                     void *id_ptr,
                                     enum IdentityType idType,
-                                    RetPtr_u8 error_ret);
+                                    RetError error_ret);
 
 /**
  * @brief Construct a Principal of the IC management canister
@@ -1035,7 +1041,7 @@ struct CPrincipal *principal_from_slice(const uint8_t *bytes, int bytes_len);
  */
 struct CPrincipal *principal_try_from_slice(const uint8_t *bytes,
                                             int bytes_len,
-                                            RetPtr_u8 error_ret);
+                                            RetError error_ret);
 
 /**
  * @brief Construct a Principal from text representation.
@@ -1046,7 +1052,7 @@ struct CPrincipal *principal_try_from_slice(const uint8_t *bytes,
  * If the function returns a NULL CPrincipal the user should check
  * The error callback, to attain the error
  */
-struct CPrincipal *principal_from_text(const char *text, RetPtr_u8 error_ret);
+struct CPrincipal *principal_from_text(const char *text, RetError error_ret);
 
 /**
  * @brief Return the textual representation of Principal.
@@ -1058,7 +1064,7 @@ struct CPrincipal *principal_from_text(const char *text, RetPtr_u8 error_ret);
  * If the function returns a NULL CPrincipal the user should check
  * The error callback, to attain the error
  */
-struct CPrincipal *principal_to_text(const uint8_t *bytes, int bytes_len, RetPtr_u8 error_ret);
+struct CPrincipal *principal_to_text(const uint8_t *bytes, int bytes_len, RetError error_ret);
 
 /**
  * @brief Free allocated Memory

--- a/lib-agent-c/src/agent_c.c
+++ b/lib-agent-c/src/agent_c.c
@@ -34,7 +34,7 @@
  * @return FFIAgent pointer 
  */
 FFIAgent *agent_create(const char *url, CIdentity *id, CPrincipal *canister,
-                const char *did_content, RetPtr_u8 error_cb) {
+                const char *did_content, RetError *error_cb) {
 
     return agent_create_wrap(url, id->ptr, id->type, canister->ptr,
                                           canister->len, did_content,
@@ -48,7 +48,7 @@ FFIAgent *agent_create(const char *url, CIdentity *id, CPrincipal *canister,
  * @param error_cb returned error
  * @return agent call result
  */
-CText* agent_status(const struct FFIAgent *agent, RetPtr_u8 error_cb) {
+CText* agent_status(const struct FFIAgent *agent, RetError *error_cb) {
     return agent_status_wrap(agent, error_cb);
 }
 
@@ -62,7 +62,7 @@ CText* agent_status(const struct FFIAgent *agent, RetPtr_u8 error_cb) {
  * @return agent call result
  */
 IDLArgs *agent_update(const struct FFIAgent *agent, const char *method,
-                IDLArgs *method_args, RetPtr_u8 error_cb) {
+                IDLArgs *method_args, RetError *error_cb) {
 
     CText *arg = idl_args_to_text(method_args);
     return agent_update_wrap(agent, method, ctext_str(arg), error_cb);
@@ -78,7 +78,7 @@ IDLArgs *agent_update(const struct FFIAgent *agent, const char *method,
  * @return agent call result
  */
 IDLArgs *agent_query(const struct FFIAgent *agent, const char *method,
-                IDLArgs *method_args, RetPtr_u8 error_cb) {
+                IDLArgs *method_args, RetError *error_cb) {
 
     CText *arg = idl_args_to_text(method_args);
     return agent_query_wrap(agent, method, ctext_str(arg), error_cb);

--- a/lib-agent-c/src/identity_c.c
+++ b/lib-agent-c/src/identity_c.c
@@ -41,8 +41,7 @@ void anonymous_identity(CIdentity *id) {
  * @param id Identity struture pointer
  * @param error_cb returned error
  */
-void basic_identity_from_pem(const char *pem_data, CIdentity *id,
-                             RetPtr_u8 error) {
+void basic_identity_from_pem(const char *pem_data, CIdentity *id, RetError *error) {
     id->type = Basic;
     id->ptr = identity_basic_from_pem(pem_data, error);
 }
@@ -57,7 +56,7 @@ void basic_identity_from_pem(const char *pem_data, CIdentity *id,
  */
 void basic_identity_from_key_pair(const uint8_t *public_key,
                                   const uint8_t *private_key_seed, CIdentity *id,
-                                  RetPtr_u8 error_ret) {
+                                  RetError *error_ret) {
     id->type = Basic;
     id->ptr = identity_basic_from_key_pair(public_key, private_key_seed, error_ret);
 }
@@ -69,8 +68,7 @@ void basic_identity_from_key_pair(const uint8_t *public_key,
  * @param id Identity struture pointer
  * @param error_cb returned error
  */
-void secp256k1_identity_from_pem(const char *pem_data, CIdentity *id,
-                                 RetPtr_u8 error) {
+void secp256k1_identity_from_pem(const char *pem_data, CIdentity *id, RetError *error) {
     id->type = Secp256k1;
     id->ptr = identity_secp256k1_from_pem(pem_data, error);
 }

--- a/lib-agent-cpp/inc/agent.h
+++ b/lib-agent-cpp/inc/agent.h
@@ -20,33 +20,36 @@
 #include <cstring>
 #include <iostream>
 #include <vector>
+#include <optional>
+#include <functional>
+#include <variant>
 
 #include "identity.h"
 #include "idl_args.h"
 #include "principal.h"
 
+
 extern "C" {
 #include "zondax_ic.h"
 }
 
+using zondax::idl_args::IdlArgs;
+
 namespace zondax::agent {
+
 class Agent {
     private:
         FFIAgent* agent;
 
     public:
-        Agent(std::string url, zondax::identity::Identity id,
-            zondax::principal::Principal principal,
-            const std::vector<char>& did_content, RetPtr_u8 error);
+        static std::variant<Agent, std::string> create_agent(std::string url, zondax::identity::Identity id,
+            zondax::principal::Principal principal, const std::vector<char>& did_content); 
+
         ~Agent();
 
-        zondax::idl_args::IdlArgs Query(std::string service,
-                                        zondax::idl_args::IdlArgs args,
-                                        RetPtr_u8 error);
-        zondax::idl_args::IdlArgs Update(std::string service,
-                                        zondax::idl_args::IdlArgs args,
-                                        RetPtr_u8 error);
-        std::string Status(RetPtr_u8 error);
+        std::variant<IdlArgs, std::string> Query(std::string service, zondax::idl_args::IdlArgs args);
+
+        std::variant<IdlArgs, std::string> Update(std::string service, zondax::idl_args::IdlArgs args);
 };
 }  // namespace zondax::agent
 

--- a/lib-agent-cpp/inc/identity.h
+++ b/lib-agent-cpp/inc/identity.h
@@ -20,6 +20,8 @@
 #include <iostream>
 #include <vector>
 #include <cstring>
+#include <variant>
+
 #include "principal.h"
 
 extern "C" {
@@ -42,14 +44,13 @@ public:
     ~Identity();
     Identity();
     static Identity Anonymous();
-    static std::optional<Identity> BasicFromPem(const std::string& pemData, RetPtr_u8 error);
-    static std::optional<Identity> BasicFromKeyPair(const std::vector<uint8_t>& publicKey,
-                                    const std::vector<uint8_t>& privateKeySeed,
-                                    RetPtr_u8 error);
-    static std::optional<Identity> Secp256k1FromPem(const std::string& pemData, RetPtr_u8 error);
+    static std::variant<Identity, std::string> BasicFromPem(const std::string& pemData);
+    static std::variant<Identity, std::string> BasicFromKeyPair(const std::vector<uint8_t>& publicKey,
+                                    const std::vector<uint8_t>& privateKeySeed);
+    static std::variant<Identity, std::string> Secp256k1FromPem(const std::string& pemData);
     static Identity Secp256k1FromPrivateKey(const std::vector<char>& privateKey);
-    std::optional<zondax::principal::Principal> Sender(RetPtr_u8 error);
-    std::optional<IdentitySign> Sign(const std::vector<uint8_t>& bytes, RetPtr_u8 error);
+    std::variant<zondax::principal::Principal, std::string> Sender();
+    std::variant<IdentitySign, std::string> Sign(const std::vector<uint8_t>& bytes);
 
     void* getPtr() const;
     IdentityType getType() const;

--- a/lib-agent-cpp/inc/idl_args.h
+++ b/lib-agent-cpp/inc/idl_args.h
@@ -32,6 +32,8 @@ private:
     IDLArgs *ptr;
 
 public:
+    // why this constructor?
+    // does this takes ownership of memory pointed by argsPtr?
     explicit IdlArgs(IDLArgs* argsPtr);
     explicit IdlArgs(std::string text);
     explicit IdlArgs(std::vector<uint8_t> bytes);
@@ -41,6 +43,8 @@ public:
     std::vector<uint8_t> getBytes();
     std::vector<zondax::idl_value::IdlValue> getVec();
     
+    // why C++ users would want to have a pointer to an opque type?
+    // it is meant to be use by us?
     IDLArgs* getPtr() const;
     ~IdlArgs();
 };

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <cstring>
 #include "principal.h"
+#include "idl_value_utils.h"
 
 
 extern "C" {
@@ -29,30 +30,13 @@ extern "C" {
 
 namespace zondax::idl_value {
 
-class IdlValue;
-
-struct Variant {
-    std::vector<uint8_t> id;
-    IdlValue *val;
-    uint64_t code;
-};
-
-struct Func {
-    std::string s;
-    zondax::principal::Principal p;
-};
-
-struct Record {
-    std::vector<std::string> keys;
-    std::vector<IdlValue> vals;
-};
-
 class IdlValue {  
 private:
     IDLValue *ptr;
 
 public:
     // Create IdlValues from types
+    IdlValue(IDLValue *ptr);
     IdlValue();
     explicit IdlValue(uint8_t val);
     explicit IdlValue(uint16_t val);
@@ -95,15 +79,13 @@ public:
     std::string getNumber();
     IdlValue getOpt();
     std::vector<IdlValue> getVec();
-    Record getRecord();
-    Variant getVariant();
-    Func getFunc();
+    // zondax::idl_value_utils::Record getRecord();
+    // zondax::idl_value_utils::Variant getVariant();
+    zondax::idl_value_utils::Func getFunc();
 
    IDLValue* getPtr() const;
    ~IdlValue();
 };
-
-
 }
 
 

--- a/lib-agent-cpp/inc/idl_value_utils.h
+++ b/lib-agent-cpp/inc/idl_value_utils.h
@@ -13,38 +13,39 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-#ifndef PRINCIPAL_H
-#define PRINCIPAL_H
+#ifndef IDL_VALUE_UTILS_H
+#define IDL_VALUE_UTILS_H
 
 #include <cstdint>
 #include <iostream>
 #include <vector>
 #include <cstring>
-#include <variant>
+#include <memory>
+
+#include "principal.h"
+// #include "idl_value.h"
+
+class IdlValue;
+
+namespace zondax::idl_value_utils {
 
 
-extern "C" {
-#include "zondax_ic.h"
-}
-
-namespace zondax::principal {
-class Principal {
-private:
-    std::vector<unsigned char> bytes;
-    CPrincipal* cPrincipal;
-
-public:
-    explicit Principal(bool anonym = true);
-    explicit Principal(const std::vector<uint8_t> &bytes);
-
-    static Principal SelfAuthenticating(const std::vector<uint8_t> &public_key);
-    static std::variant<Principal, std::string>  TryFromSlice(const std::vector<uint8_t> &bytes);
-    static std::variant<Principal, std::string>   FromText(const std::string& text);
-    static std::string ToText(const std::vector<uint8_t> &bytes);
-
-    std::vector<unsigned char> getBytes() const;
-    ~Principal();
+struct Func {
+    std::string s;
+    zondax::principal::Principal p;
 };
 
-}
-#endif  // PRINCIPAL_H
+struct Record {
+    std::vector<std::string> keys;
+    std::vector<std::unique_ptr<IdlValue *>> vals;
+};
+
+struct Variant {
+    std::vector<uint8_t> id;
+    IdlValue *val;
+    uint64_t code;
+};
+
+}// namespace
+
+#endif

--- a/lib-agent-cpp/src/idl_args.cpp
+++ b/lib-agent-cpp/src/idl_args.cpp
@@ -51,9 +51,9 @@ std::string IdlArgs::getText() {
 }
 
 std::vector<uint8_t> IdlArgs::getBytes() {
-    RetPtr_u8 error;
 
-    CBytes* cBytes = idl_args_to_bytes(ptr, error);
+    // TODO: Remove null and use proper callback if needed
+    CBytes* cBytes = idl_args_to_bytes(ptr, nullptr);
     const uint8_t* byte = cbytes_ptr(cBytes);
     uintptr_t len = cbytes_len(cBytes);
 


### PR DESCRIPTION
Changes aim to improve the usage of error_cb mechanism:
- the error_cb is no longer required, it is possible to pass NULL
- The error_cb argument was removed from public classes and methods in cpp lib.
- Change return type from Optional to Variant in  fallible methods of C++ classes. 
- Update cpp-examples accordingly.
- Update c-examples accordingly

Note:

- IdlValue class is still in progress, there is an issue with cyclic dependencies which is not easy to resolve, a way is to use forwarding but it might make things trickier.
- Need to clean up c-examples and cpp-examples, also try to add an fallible example to check cpp-error mechanism works(this should, it is just as a double check).

<!-- ClickUpRef: 861mz4yp9 -->
:link: [zboto Link](https://app.clickup.com/t/861mz4yp9)