### PR TITLE
Move semantics

### DIFF
--- a/_clang-format
+++ b/_clang-format
@@ -1,0 +1,226 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/examples-cpp/candid/candid.cpp
+++ b/examples-cpp/candid/candid.cpp
@@ -14,29 +14,13 @@
  *  limitations under the License.
  ********************************************************************************/
 #include <iostream>
-#include "helper.h"
+
 #include "agent.h"
+#include "helper.h"
 extern "C" {
 #include "helper_c.h"
 }
 
-using namespace zondax::agent;
-using namespace zondax::principal;
-using namespace zondax::identity;
-using namespace zondax::idl_args;
-using namespace zondax::idl_value;
+using namespace zondax;
 
-Error error_cpp;
-
-void error_cb_cpp(const uint8_t* p, int len) {
-    if (error_cpp.ptr != nullptr) {
-         free((void*)error_cpp.ptr);
-    }
-    error_cpp.ptr = static_cast<const uint8_t*>(malloc(len));
-    error_cpp.len = len;
-    memcpy((void*)error_cpp.ptr, p, len);
-}
-
-int main() {
-
-}
+int main() {}

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -30,7 +30,7 @@ int main() {
     // Canister info from hello world deploy example
     std::string id_text = "rdmx6-jaaaa-aaaaa-aaadq-cai";
     // path is relative to binary location, not source
-    std::string did_file = "examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
+    std::string did_file = "../examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
     std::string url = "https://ic0.app";
 
     std::vector<char> buffer;

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -18,9 +18,6 @@
 #include "agent.h"
 #include "idl_value.h"
 
-extern "C" {
-#include "helper_c.h"
-}
 #include "helper.h"
 
 using namespace zondax::agent;
@@ -32,19 +29,17 @@ using namespace zondax::idl_value;
 int main() {
     // Canister info from hello world deploy example
     std::string id_text = "rdmx6-jaaaa-aaaaa-aaadq-cai";
-    std::string did_file = "../examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
+    // path is relative to binary location, not source
+    std::string did_file = "examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
     std::string url = "https://ic0.app";
 
-    // Get did file content
-    long file_size = did_file_size(did_file);
-    std::vector<char> buffer(file_size + 1);
-    int result = did_file_content(did_file, file_size, buffer.data());
+    std::vector<char> buffer;
+    auto bytes_read = did_file_content(did_file, buffer);
 
     //Get principal form text
     auto principal = Principal::FromText(id_text);
 
     if(std::holds_alternative<std::string>(principal)) {
-        std::cout<<"Error: "<<std::get<std::string>(principal)<<std::endl;
         return -1;
     }
     
@@ -55,7 +50,7 @@ int main() {
     auto agent = Agent::create_agent(url, std::move(anonymousIdentity), std::move(std::get<Principal>(principal)), buffer);
 
     if (std::holds_alternative<std::string>(agent)) {
-        std::cout<<"Error: "<<std::get<std::string>(agent)<<std::endl;
+        std::cerr<<"Error: "<<std::get<std::string>(agent)<<std::endl;
         return -1;
     }
 

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -67,11 +67,8 @@ int main() {
     std::vector<zondax::idl_value::IdlValue*> values;
     values.push_back(&elem);
 
-    // Create an IdlArgs object using the vector of IdlValue pointers
-    IdlArgs args(values);
-
-    //Make Query call to canister
-    auto out = std::get<Agent>(agent).Query("lookup", args);
+    //Make Query call to canister, pass args using move semantics
+    auto out = std::get<Agent>(agent).Query("lookup", IdlArgs(values));
 
 
     //Get text representation and print

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -56,14 +56,15 @@ int main() {
 
     // Create an IdlValue object with the uint64_t value (nat64 in candid)
     uint64_t nat64 = 1974211;
-    auto elem = zondax::idl_value::IdlValue(nat64);
 
     // Create a vector of IdlValue pointers
-    std::vector<zondax::idl_value::IdlValue*> values;
-    values.push_back(&elem);
+    std::vector<zondax::idl_value::IdlValue> values;
+    values.emplace_back(zondax::idl_value::IdlValue(nat64));
+
+    auto args = IdlArgs(std::move(values));
 
     //Make Query call to canister, pass args using move semantics
-    auto out = std::get<Agent>(agent).Query("lookup", IdlArgs(values));
+    auto out = std::get<Agent>(agent).Query("lookup", std::move(args));
 
 
     //Get text representation and print

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -15,61 +15,58 @@
  ********************************************************************************/
 #include <iostream>
 #include <variant>
+
 #include "agent.h"
+#include "helper.h"
 #include "idl_value.h"
 
-#include "helper.h"
-
-using namespace zondax::agent;
-using namespace zondax::principal;
-using namespace zondax::identity;
-using namespace zondax::idl_args;
-using namespace zondax::idl_value;
+using namespace zondax;
 
 int main() {
-    // Canister info from hello world deploy example
-    std::string id_text = "rdmx6-jaaaa-aaaaa-aaadq-cai";
-    // path is relative to binary location, not source
-    std::string did_file = "../examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
-    std::string url = "https://ic0.app";
+  // Canister info from hello world deploy example
+  std::string id_text = "rdmx6-jaaaa-aaaaa-aaadq-cai";
+  // path is relative to binary location, not source
+  std::string did_file = "../examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
+  std::string url = "https://ic0.app";
 
-    std::vector<char> buffer;
-    auto bytes_read = did_file_content(did_file, buffer);
+  std::vector<char> buffer;
+  auto bytes_read = did_file_content(did_file, buffer);
 
-    //Get principal form text
-    auto principal = Principal::FromText(id_text);
+  // Get principal form text
+  auto principal = Principal::FromText(id_text);
 
-    if(std::holds_alternative<std::string>(principal)) {
-        return -1;
-    }
-    
-    //Construct anonymoous id
-    Identity anonymousIdentity;
-    
-    //Create agent with agent constructor
-    auto agent = Agent::create_agent(url, std::move(anonymousIdentity), std::move(std::get<Principal>(principal)), buffer);
+  if (std::holds_alternative<std::string>(principal)) {
+    return -1;
+  }
 
-    if (std::holds_alternative<std::string>(agent)) {
-        std::cerr<<"Error: "<<std::get<std::string>(agent)<<std::endl;
-        return -1;
-    }
+  // Construct anonymoous id
+  Identity anonymousIdentity;
 
-    // Create an IdlValue object with the uint64_t value (nat64 in candid)
-    uint64_t nat64 = 1974211;
+  // Create agent with agent constructor
+  auto agent =
+      Agent::create_agent(url, std::move(anonymousIdentity),
+                          std::move(std::get<Principal>(principal)), buffer);
 
-    // Create a vector of IdlValue pointers
-    std::vector<zondax::idl_value::IdlValue> values;
-    values.emplace_back(zondax::idl_value::IdlValue(nat64));
+  if (std::holds_alternative<std::string>(agent)) {
+    std::cerr << "Error: " << std::get<std::string>(agent) << std::endl;
+    return -1;
+  }
 
-    auto args = IdlArgs(std::move(values));
+  // Create an IdlValue object with the uint64_t value (nat64 in candid)
+  uint64_t nat64 = 1974211;
 
-    //Make Query call to canister, pass args using move semantics
-    auto out = std::get<Agent>(agent).Query("lookup", args);
+  // Create a vector of IdlValue pointers
+  std::vector<IdlValue> values;
+  values.emplace_back(IdlValue(nat64));
 
+  auto args = IdlArgs(std::move(values));
 
-    //Get text representation and print
-    std::string out_text = std::get<IdlArgs>(out).getText();
-    std::cout << out_text << std::endl;
+  // Make Query call to canister, pass args using move semantics
+  auto out = std::get<Agent>(agent).Query("lookup", args);
 
-    return 0;
+  // Get text representation and print
+  std::string out_text = std::get<IdlArgs>(out).getText();
+  std::cout << out_text << std::endl;
+
+  return 0;
 }

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -64,7 +64,7 @@ int main() {
     auto args = IdlArgs(std::move(values));
 
     //Make Query call to canister, pass args using move semantics
-    auto out = std::get<Agent>(agent).Query("lookup", std::move(args));
+    auto out = std::get<Agent>(agent).Query("lookup", args);
 
 
     //Get text representation and print

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -52,7 +52,7 @@ int main() {
     Identity anonymousIdentity;
     
     //Create agent with agent constructor
-    auto agent = Agent::create_agent(url, std::move(anonymousIdentity), std::get<Principal>(principal), buffer);
+    auto agent = Agent::create_agent(url, std::move(anonymousIdentity), std::move(std::get<Principal>(principal)), buffer);
 
     if (std::holds_alternative<std::string>(agent)) {
         std::cout<<"Error: "<<std::get<std::string>(agent)<<std::endl;

--- a/examples-cpp/ic/ic.cpp
+++ b/examples-cpp/ic/ic.cpp
@@ -52,7 +52,7 @@ int main() {
     Identity anonymousIdentity;
     
     //Create agent with agent constructor
-    auto agent = Agent::create_agent(url, anonymousIdentity, std::get<Principal>(principal), buffer);
+    auto agent = Agent::create_agent(url, std::move(anonymousIdentity), std::get<Principal>(principal), buffer);
 
     if (std::holds_alternative<std::string>(agent)) {
         std::cout<<"Error: "<<std::get<std::string>(agent)<<std::endl;

--- a/examples-cpp/identity/identity.cpp
+++ b/examples-cpp/identity/identity.cpp
@@ -13,22 +13,22 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-#include <iostream>
 #include "identity.h"
+
+#include <iostream>
 
 extern "C" {
 #include "helper_c.h"
 }
 
-using namespace zondax::identity;
-using namespace zondax::principal;
+using namespace zondax;
 
 Error error_cpp;
 
 // TODO: Add example to verify callback mechanism works fine!!!!
 
-
-std::string basic_expected = "emrl6-qe3wz-fh5ib-sx2r4-fbx46-6g4ql-5ro3g-zhbtm-nxdrq-q2oqo-jqe";
+std::string basic_expected =
+    "emrl6-qe3wz-fh5ib-sx2r4-fbx46-6g4ql-5ro3g-zhbtm-nxdrq-q2oqo-jqe";
 
 std::string BasicIdentityFile =
     "-----BEGIN PRIVATE KEY-----\n"
@@ -37,80 +37,82 @@ std::string BasicIdentityFile =
     "-----END PRIVATE KEY-----";
 
 std::vector<uint8_t> PubKeyExpected = {
-    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00, 0x42, 0x90,
-    0x4d, 0x4d, 0x2f, 0x85, 0xf8, 0xdd, 0xc9, 0x57, 0x4b, 0x52, 0xc5, 0x6a, 0xe8, 0x9c,
-    0x7a, 0x28, 0x8a, 0x5b, 0xd3, 0x61, 0x8d, 0x54, 0xc4, 0xa5, 0x4e, 0x8b, 0xa4, 0x7f,
-    0x50, 0x73
-};
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21,
+    0x00, 0x42, 0x90, 0x4d, 0x4d, 0x2f, 0x85, 0xf8, 0xdd, 0xc9, 0x57,
+    0x4b, 0x52, 0xc5, 0x6a, 0xe8, 0x9c, 0x7a, 0x28, 0x8a, 0x5b, 0xd3,
+    0x61, 0x8d, 0x54, 0xc4, 0xa5, 0x4e, 0x8b, 0xa4, 0x7f, 0x50, 0x73};
 
 std::vector<uint8_t> SignatureExpected = {
-    0x6d, 0x7a, 0x2f, 0x85, 0xeb, 0x6c, 0xc2, 0x18, 0x80, 0xc8, 0x3d, 0x9b, 0xb1, 0x70,
-    0xe2, 0x4b, 0xf5, 0xd8, 0x9a, 0xa9, 0x96, 0x92, 0xb6, 0x89, 0xac, 0x9d, 0xe9, 0x5c,
-    0x1e, 0x3e, 0x50, 0xdc, 0x98, 0x12, 0x2f, 0x94, 0x11, 0x2f, 0x6c, 0xc6, 0x6a, 0x0b,
-    0xbf, 0xc0, 0x56, 0x5b, 0xdb, 0x87, 0xa9, 0xe2, 0x2c, 0x8e, 0x56, 0x94, 0x56, 0x12,
-    0xde, 0xbf, 0x22, 0x4a, 0x3f, 0xdb, 0xf1, 0x03
-};
+    0x6d, 0x7a, 0x2f, 0x85, 0xeb, 0x6c, 0xc2, 0x18, 0x80, 0xc8, 0x3d,
+    0x9b, 0xb1, 0x70, 0xe2, 0x4b, 0xf5, 0xd8, 0x9a, 0xa9, 0x96, 0x92,
+    0xb6, 0x89, 0xac, 0x9d, 0xe9, 0x5c, 0x1e, 0x3e, 0x50, 0xdc, 0x98,
+    0x12, 0x2f, 0x94, 0x11, 0x2f, 0x6c, 0xc6, 0x6a, 0x0b, 0xbf, 0xc0,
+    0x56, 0x5b, 0xdb, 0x87, 0xa9, 0xe2, 0x2c, 0x8e, 0x56, 0x94, 0x56,
+    0x12, 0xde, 0xbf, 0x22, 0x4a, 0x3f, 0xdb, 0xf1, 0x03};
 
 int main() {
-    // Creating an anonymous identity
-    Identity anonymousIdentity;
+  // Creating an anonymous identity
+  Identity anonymousIdentity;
 
-    // Getting the sender principal
-    auto senderPrincipal = anonymousIdentity.Sender();
+  // Getting the sender principal
+  auto senderPrincipal = anonymousIdentity.Sender();
 
-    if(std::holds_alternative<Principal>(senderPrincipal)) {
+  if (std::holds_alternative<Principal>(senderPrincipal)) {
+    std::vector<unsigned char> bytes =
+        std::get<Principal>(senderPrincipal).getBytes();
 
-        std::vector<unsigned char> bytes = std::get<Principal>(senderPrincipal).getBytes();
-
-        if (bytes.size() == 1 && bytes[0] == 4 && anonymousIdentity.getType() == Anonym) {
-            std::cout << "Test 1: Valid Anonym identity" << std::endl;
-        } else {
-            std::cout << "Test 1: Invalid Anonym identity" << std::endl;
-        }
-
+    if (bytes.size() == 1 && bytes[0] == 4 &&
+        anonymousIdentity.getType() == Anonym) {
+      std::cout << "Test 1: Valid Anonym identity" << std::endl;
     } else {
-        std::cout << "Test 1: "<< std::get<std::string>(senderPrincipal) << std::endl;
+      std::cout << "Test 1: Invalid Anonym identity" << std::endl;
     }
 
-    // Creating an Basic Identity
-    auto id = Identity::BasicFromPem(BasicIdentityFile);
+  } else {
+    std::cout << "Test 1: " << std::get<std::string>(senderPrincipal)
+              << std::endl;
+  }
 
-    if (!std::holds_alternative<Identity>(id)) {
-        std::cout << std::get<std::string>(id)<<std::endl;
-        return -1;
-    }
+  // Creating an Basic Identity
+  auto id = Identity::BasicFromPem(BasicIdentityFile);
 
-    // Getting the sender principal
-    auto idPrincipal = std::get<Identity>(id).Sender();
+  if (!std::holds_alternative<Identity>(id)) {
+    std::cout << std::get<std::string>(id) << std::endl;
+    return -1;
+  }
 
-    if ( std::holds_alternative<std::string>(idPrincipal) ) {
-        std::cout<<"Error:  "<<std::get<std::string>(idPrincipal)<<std::endl;
-        return -1;
-    }
+  // Getting the sender principal
+  auto idPrincipal = std::get<Identity>(id).Sender();
 
-    std::string str = Principal::ToText(std::get<Principal>(idPrincipal).getBytes());
+  if (std::holds_alternative<std::string>(idPrincipal)) {
+    std::cout << "Error:  " << std::get<std::string>(idPrincipal) << std::endl;
+    return -1;
+  }
 
-    // Creating an Basic Identity
-    auto basic = Identity::BasicFromPem(BasicIdentityFile);
+  std::string str =
+      Principal::ToText(std::get<Principal>(idPrincipal).getBytes());
 
-    if ( std::holds_alternative<std::string>(basic) ) {
-        std::cout<<"Error:  "<<std::get<std::string>(basic)<<std::endl;
-        return -1;
-    }
-    // identitySign
-    auto result = std::get<Identity>(basic).Sign({});
+  // Creating an Basic Identity
+  auto basic = Identity::BasicFromPem(BasicIdentityFile);
 
-    if ( std::holds_alternative<std::string>(result) ) {
-        std::cout<<"Error:  "<<std::get<std::string>(result)<<std::endl;
-        return -1;
-    }
+  if (std::holds_alternative<std::string>(basic)) {
+    std::cout << "Error:  " << std::get<std::string>(basic) << std::endl;
+    return -1;
+  }
+  // identitySign
+  auto result = std::get<Identity>(basic).Sign({});
 
-    auto value = std::get<IdentitySign>(result);
-    if(value.pubkey == PubKeyExpected && value.signature == SignatureExpected) {
-        std::cout << "Test 3: Valid Sign Basic" << std::endl;
-    } else {
-        std::cout << "Test 3: Invalid Sign Basic" << std::endl;
-    }
+  if (std::holds_alternative<std::string>(result)) {
+    std::cout << "Error:  " << std::get<std::string>(result) << std::endl;
+    return -1;
+  }
 
-    return 0;
+  auto value = std::get<IdentitySign>(result);
+  if (value.pubkey == PubKeyExpected && value.signature == SignatureExpected) {
+    std::cout << "Test 3: Valid Sign Basic" << std::endl;
+  } else {
+    std::cout << "Test 3: Invalid Sign Basic" << std::endl;
+  }
+
+  return 0;
 }

--- a/examples-cpp/principal/principal.cpp
+++ b/examples-cpp/principal/principal.cpp
@@ -13,131 +13,128 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+#include "principal.h"
+
 #include <iostream>
 #include <variant>
-#include "principal.h"
 
 extern "C" {
 #include "helper_c.h"
 }
 
-using namespace zondax::principal;
+using namespace zondax;
 
 int main() {
-    
-    // Get Management Principal
-    Principal management(false);
+  // Get Management Principal
+  Principal management(false);
 
-    std::vector<unsigned char> bytes = management.getBytes();
+  std::vector<unsigned char> bytes = management.getBytes();
 
-    if (bytes.size() == 0 ) {
-        std::cout << "Test 1: Valid Principal Management" << std::endl;
-    } else {
-        std::cout << "Test 1: Invalid Principal Management" << std::endl;
-    }
+  if (bytes.size() == 0) {
+    std::cout << "Test 1: Valid Principal Management" << std::endl;
+  } else {
+    std::cout << "Test 1: Invalid Principal Management" << std::endl;
+  }
 
-    // Get Anonymous Principal
-    Principal anonym;
+  // Get Anonymous Principal
+  Principal anonym;
 
-    bytes = anonym.getBytes();
+  bytes = anonym.getBytes();
 
-    if (bytes.size() == 1 && bytes[0] == 4) {
-        std::cout << "Test 2: Valid Principal Anonymous" << std::endl;
-    } else {
-        std::cout << "Test 2: Invalid Principal Anonymous" << std::endl;
-    }
+  if (bytes.size() == 1 && bytes[0] == 4) {
+    std::cout << "Test 2: Valid Principal Anonymous" << std::endl;
+  } else {
+    std::cout << "Test 2: Invalid Principal Anonymous" << std::endl;
+  }
 
-    // Get SelfAuthenticating Principal
-    std::vector<uint8_t> publicKey=
-    {
-        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22,
-        0x11, 0x00, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44,
-        0x33, 0x22, 0x11, 0x00,
-    };
+  // Get SelfAuthenticating Principal
+  std::vector<uint8_t> publicKey = {
+      0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55,
+      0x44, 0x33, 0x22, 0x11, 0x00, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa,
+      0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+  };
 
-    std::vector<uint8_t> bytesExpected=
-    {
-        0x2f, 0x8e, 0x47, 0x38, 0xf9, 0xd7, 0x68, 0x16, 0x82, 0x99, 0x85, 0x41, 0x52, 0x67,
-        0x86, 0x38, 0x07, 0xd3, 0x7d, 0x20, 0x6a, 0xd9, 0x0f, 0xea, 0x72, 0xbf, 0x9d, 0xcf,
-        0x02,
-    };
+  std::vector<uint8_t> bytesExpected = {
+      0x2f, 0x8e, 0x47, 0x38, 0xf9, 0xd7, 0x68, 0x16, 0x82, 0x99,
+      0x85, 0x41, 0x52, 0x67, 0x86, 0x38, 0x07, 0xd3, 0x7d, 0x20,
+      0x6a, 0xd9, 0x0f, 0xea, 0x72, 0xbf, 0x9d, 0xcf, 0x02,
+  };
 
-    Principal p = Principal::SelfAuthenticating(publicKey);
+  Principal p = Principal::SelfAuthenticating(publicKey);
 
-    bytes = p.getBytes();
+  bytes = p.getBytes();
 
-    if (bytes.size() == bytesExpected.size() &&
-        std::equal(bytes.begin(), bytes.end(), std::begin(bytesExpected))) {
-        std::cout << "Test 3: Valid Principal Self Authenticating" << std::endl;
-    } else {
-        std::cout << "Test 3: Invalid Principal Self Authenticating" << std::endl;
-    }
+  if (bytes.size() == bytesExpected.size() &&
+      std::equal(bytes.begin(), bytes.end(), std::begin(bytesExpected))) {
+    std::cout << "Test 3: Valid Principal Self Authenticating" << std::endl;
+  } else {
+    std::cout << "Test 3: Invalid Principal Self Authenticating" << std::endl;
+  }
 
+  // Get Principal from slice of bytes
+  std::vector<uint8_t> slice = {0x1};
 
-    // Get Principal from slice of bytes
-    std::vector<uint8_t> slice = {0x1};
+  Principal principal(slice);
 
-    Principal principal(slice);
+  bytes = principal.getBytes();
 
-    bytes = principal.getBytes();
+  if (bytes.size() == 1 && static_cast<int>(bytes[0]) == 0x1) {
+    std::cout << "Test 4.0: Valid Principal from bytes" << std::endl;
+  } else {
+    std::cout << "Test 4.0: Invalid Principal from bytes" << std::endl;
+  }
 
-    if (bytes.size() == 1 && static_cast<int>(bytes[0])==0x1 ) {
-        std::cout << "Test 4.0: Valid Principal from bytes" << std::endl;
-    } else {
-        std::cout << "Test 4.0: Invalid Principal from bytes" << std::endl;
-    }
+  // IF we send a byte array bigger than 29 an error is expected
+  std::vector<uint8_t> slice_long = {
+      0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55,
+      0x44, 0x33, 0x22, 0x11, 0x00, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa,
+      0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+  };
 
-    // IF we send a byte array bigger than 29 an error is expected
-    std::vector<uint8_t> slice_long = {
-        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22,
-        0x11, 0x00, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44,
-        0x33, 0x22, 0x11, 0x00,
-    };
+  auto result = Principal::TryFromSlice(slice_long);
 
-   auto result = Principal::TryFromSlice(slice_long);
+  if (!std::holds_alternative<Principal>(result)) {
+    std::cout << "Test 4.1: " << std::get<std::string>(result) << std::endl;
+    return -1;
+  }
 
-    if(!std::holds_alternative<Principal>(result)) {
-        std::cout << "Test 4.1: "<< std::get<std::string>(result)<< std::endl;
-        return -1;
-    }
+  bytes = std::get<Principal>(result).getBytes();
+  if (bytes.size() == slice_long.size() &&
+      std::equal(bytes.begin(), bytes.end(), std::begin(slice_long))) {
+    std::cout << "Test 4.1: Valid Principal from slice" << std::endl;
+  } else {
+    std::cout << "Test 4.1: Invalid Principal from slice" << std::endl;
+  }
 
-    bytes = std::get<Principal>( result ).getBytes();
-    if (bytes.size() == slice_long.size() &&
-        std::equal(bytes.begin(), bytes.end(), std::begin(slice_long))) {
-            std::cout << "Test 4.1: Valid Principal from slice" << std::endl;
-        } else {
-        std::cout << "Test 4.1: Invalid Principal from slice" << std::endl;
-    }
+  // Get principal from Text , testing with anonymous principal
+  std::string text = "2vxsx-fae";
 
-    // Get principal from Text , testing with anonymous principal
-    std::string text = "2vxsx-fae";
-    
-    auto result2 = Principal::FromText(text);
+  auto result2 = Principal::FromText(text);
 
-    if(!std::holds_alternative<Principal>(result2)) {
-        std::cout << "Test 5: "<< std::get<std::string>(result2)<< std::endl;
-        return -1;
-    }
-    
-    bytes = std::get<Principal>( result2 ).getBytes();
+  if (!std::holds_alternative<Principal>(result2)) {
+    std::cout << "Test 5: " << std::get<std::string>(result2) << std::endl;
+    return -1;
+  }
 
-    if (bytes.size() == 1 && bytes[0] == 4) {
-        std::cout << "Test 5: Valid Principal from text" << std::endl;
-    } else {
-        std::cout << "Test 5: Invalid Principal from text" << std::endl;
-        return -1;
-    }
+  bytes = std::get<Principal>(result2).getBytes();
 
-    // Get Text from principal, testing with anonymous principal
-    std::vector<unsigned char> p_slice= { 4 };
+  if (bytes.size() == 1 && bytes[0] == 4) {
+    std::cout << "Test 5: Valid Principal from text" << std::endl;
+  } else {
+    std::cout << "Test 5: Invalid Principal from text" << std::endl;
+    return -1;
+  }
 
-    std::string str = Principal::ToText(p_slice);
-    
-    if (str == text) {
-        std::cout << "Test 6: Valid Text from Principal"<< std::endl;
-    } else {
-        std::cout << "Test 6: Invalid Text from Principal"<< std::endl;
-    }
+  // Get Text from principal, testing with anonymous principal
+  std::vector<unsigned char> p_slice = {4};
 
-    return 0;
+  std::string str = Principal::ToText(p_slice);
+
+  if (str == text) {
+    std::cout << "Test 6: Valid Text from Principal" << std::endl;
+  } else {
+    std::cout << "Test 6: Invalid Text from Principal" << std::endl;
+  }
+
+  return 0;
 }

--- a/examples/ic_c/ic_c.c
+++ b/examples/ic_c/ic_c.c
@@ -99,6 +99,7 @@ int main(void) {
     free(did_content);
     free((void *) error.ptr);
     principal_destroy(principal);
+    identity_destroy(id.ptr, id.type);
     agent_destroy(agent_1);
     idl_args_destroy(idl_args_ptr);
     idl_args_destroy(call_1);

--- a/examples/ic_c/ic_c.c
+++ b/examples/ic_c/ic_c.c
@@ -48,7 +48,7 @@ int main(void) {
 
     // Canister info from hello world deploy example
     const char *id_text = "rdmx6-jaaaa-aaaaa-aaadq-cai";
-    const char *did_file = "../examples/icp-app/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
+    const char *did_file = "../examples/ic_c/rdmx6-jaaaa-aaaaa-aaadq-cai.did";
     const char *url = "https://ic0.app";
 
     // Get did file content

--- a/ic-agent-wrapper/bindings.h
+++ b/ic-agent-wrapper/bindings.h
@@ -1015,6 +1015,16 @@ struct CIdentitySign *identity_sign(const uint8_t *bytes,
                                     struct RetError *error_ret);
 
 /**
+ * @brief Free allocated Memory
+ *
+ * @param identity Identity pointer
+ * @param idType Identity Type
+ * Rust code will deal the memory allocation but the user should guarantee
+ * The memory is free when isn't needed anymore
+ */
+void identity_destroy(void *identity, enum IdentityType idType);
+
+/**
  * @brief Construct a Principal of the IC management canister
  *
  * @return Pointer to CPrincipal structure

--- a/ic-agent-wrapper/bindings.h
+++ b/ic-agent-wrapper/bindings.h
@@ -411,6 +411,22 @@ IDLArgs *agent_update_wrap(const struct FFIAgent *agent_ptr,
 void agent_destroy(struct FFIAgent *_agent);
 
 /**
+ * @brief Creates and empty IDLArgs
+ *
+ * @return An IDLArgs object containing an empty list IDLValues
+ */
+IDLArgs *empty_idl_args(void);
+
+/**
+ * @brief Push a new IDLValue into values list
+ * @param args The IDLArgs instance where `value` would be added.
+ * @param value that is going to be pushed into
+ * the list.
+ * @note: This takes ownership of the passed value
+ */
+void idl_args_push_value(IDLArgs *args, IDLValue *value);
+
+/**
  * @brief Translate IDLArgs to text
  *
  * @param idl_args Pointer to IdlArgs

--- a/ic-agent-wrapper/src/candid/mod.rs
+++ b/ic-agent-wrapper/src/candid/mod.rs
@@ -34,6 +34,27 @@ use crate::{
 * Candid Args
 ********************************************************************************/
 
+/// @brief Creates and empty IDLArgs
+///
+/// @return An IDLArgs object containing an empty list IDLValues
+#[no_mangle]
+pub extern "C" fn empty_idl_args() -> Box<IDLArgs> {
+    // use dummy idl_value
+    let values = [IDLValue::Bool(false); 0];
+    let args = IDLArgs::new(values.as_slice());
+    Box::new(args)
+}
+
+/// @brief Push a new IDLValue into values list 
+/// @param args The IDLArgs instance where `value` would be added. 
+/// @param value that is going to be pushed into 
+/// the list.
+/// @note: This takes ownership of the passed value
+#[no_mangle]
+pub extern "C" fn idl_args_push_value(args: &mut IDLArgs, value: Box<IDLValue> ) {
+    args.args.push(*value);
+}
+
 /// @brief Translate IDLArgs to text
 ///
 /// @param idl_args Pointer to IdlArgs

--- a/ic-agent-wrapper/src/identity/mod.rs
+++ b/ic-agent-wrapper/src/identity/mod.rs
@@ -396,6 +396,29 @@ pub extern "C" fn identity_sign(
     }
 }
 
+/// @brief Free allocated Memory
+///
+/// @param identity Identity pointer 
+/// @param idType Identity Type
+/// Rust code will deal the memory allocation but the user should guarantee
+/// The memory is free when isn't needed anymore
+#[no_mangle]
+pub extern "C" fn identity_destroy(identity: *mut c_void, idType: IdentityType ) {
+    if !identity.is_null() {
+            match idType {
+                IdentityType::Anonym => {
+                    let _id = unsafe { Box::from_raw(identity as *mut AnonymousIdentity) };
+                }
+                IdentityType::Basic => {
+                    let _id = unsafe { Box::from_raw(identity as *mut BasicIdentity) };
+                }
+                IdentityType::Secp256k1 => {
+                    let _id = unsafe { Box::from_raw(identity as *mut Secp256k1Identity) };
+                }
+            }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use candid::Principal;

--- a/lib-agent-c/inc/zondax_ic.h
+++ b/lib-agent-c/inc/zondax_ic.h
@@ -1015,6 +1015,16 @@ struct CIdentitySign *identity_sign(const uint8_t *bytes,
                                     struct RetError *error_ret);
 
 /**
+ * @brief Free allocated Memory
+ *
+ * @param identity Identity pointer
+ * @param idType Identity Type
+ * Rust code will deal the memory allocation but the user should guarantee
+ * The memory is free when isn't needed anymore
+ */
+void identity_destroy(void *identity, enum IdentityType idType);
+
+/**
  * @brief Construct a Principal of the IC management canister
  *
  * @return Pointer to CPrincipal structure

--- a/lib-agent-c/inc/zondax_ic.h
+++ b/lib-agent-c/inc/zondax_ic.h
@@ -411,6 +411,22 @@ IDLArgs *agent_update_wrap(const struct FFIAgent *agent_ptr,
 void agent_destroy(struct FFIAgent *_agent);
 
 /**
+ * @brief Creates and empty IDLArgs
+ *
+ * @return An IDLArgs object containing an empty list IDLValues
+ */
+IDLArgs *empty_idl_args(void);
+
+/**
+ * @brief Push a new IDLValue into values list
+ * @param args The IDLArgs instance where `value` would be added.
+ * @param value that is going to be pushed into
+ * the list.
+ * @note: This takes ownership of the passed value
+ */
+void idl_args_push_value(IDLArgs *args, IDLValue *value);
+
+/**
  * @brief Translate IDLArgs to text
  *
  * @param idl_args Pointer to IdlArgs

--- a/lib-agent-cpp/inc/agent.h
+++ b/lib-agent-cpp/inc/agent.h
@@ -60,7 +60,7 @@ class Agent {
 
         ~Agent();
 
-        std::variant<IdlArgs, std::string> Query(std::string service, zondax::idl_args::IdlArgs args);
+        std::variant<IdlArgs, std::string> Query(std::string service, zondax::idl_args::IdlArgs &args);
 
         std::variant<IdlArgs, std::string> Update(std::string service, zondax::idl_args::IdlArgs args);
 };

--- a/lib-agent-cpp/inc/agent.h
+++ b/lib-agent-cpp/inc/agent.h
@@ -41,7 +41,20 @@ class Agent {
     private:
         FFIAgent* agent;
 
+        Agent() noexcept{
+            agent = nullptr;
+        };
+
     public:
+        // Disable copies, just move semantics
+        Agent(const Agent &args) = delete;
+        void operator=(const Agent&) = delete;
+
+        // declare move constructor
+        Agent(Agent &&o) noexcept;
+        // declare move assignment
+        Agent& operator=(Agent &&o) noexcept;
+
         static std::variant<Agent, std::string> create_agent(std::string url, zondax::identity::Identity id,
             zondax::principal::Principal principal, const std::vector<char>& did_content); 
 

--- a/lib-agent-cpp/inc/agent.h
+++ b/lib-agent-cpp/inc/agent.h
@@ -18,52 +18,55 @@
 
 #include <cstdint>
 #include <cstring>
-#include <iostream>
-#include <vector>
-#include <optional>
 #include <functional>
+#include <iostream>
+#include <optional>
 #include <variant>
+#include <vector>
 
 #include "identity.h"
 #include "idl_args.h"
 #include "principal.h"
 
-
 extern "C" {
 #include "zondax_ic.h"
 }
 
-using zondax::idl_args::IdlArgs;
+using zondax::IdlArgs;
 
-namespace zondax::agent {
+namespace zondax {
 
 class Agent {
-    private:
-        FFIAgent* agent;
+ private:
+  FFIAgent *agent;
 
-        Agent() noexcept{
-            agent = nullptr;
-        };
+  Agent() noexcept { agent = nullptr; };
 
-    public:
-        // Disable copies, just move semantics
-        Agent(const Agent &args) = delete;
-        void operator=(const Agent&) = delete;
+  static void error_callback(const unsigned char *data, int len,
+                             void *user_data);
 
-        // declare move constructor
-        Agent(Agent &&o) noexcept;
-        // declare move assignment
-        Agent& operator=(Agent &&o) noexcept;
+ public:
+  // Disable copies, just move semantics
+  Agent(const Agent &args) = delete;
+  void operator=(const Agent &) = delete;
 
-        static std::variant<Agent, std::string> create_agent(std::string url, zondax::identity::Identity id,
-            zondax::principal::Principal principal, const std::vector<char>& did_content); 
+  // declare move constructor
+  Agent(Agent &&o) noexcept;
+  // declare move assignment
+  Agent &operator=(Agent &&o) noexcept;
 
-        ~Agent();
+  static std::variant<Agent, std::string> create_agent(
+      std::string url, zondax::Identity id, zondax::Principal principal,
+      const std::vector<char> &did_content);
 
-        std::variant<IdlArgs, std::string> Query(std::string service, zondax::idl_args::IdlArgs &args);
+  ~Agent();
 
-        std::variant<IdlArgs, std::string> Update(std::string service, zondax::idl_args::IdlArgs args);
+  std::variant<IdlArgs, std::string> Query(std::string service,
+                                           zondax::IdlArgs &args);
+
+  std::variant<IdlArgs, std::string> Update(std::string service,
+                                            zondax::IdlArgs &args);
 };
-}  // namespace zondax::agent
+}  // namespace zondax
 
 #endif  // IDENTITY_H

--- a/lib-agent-cpp/inc/helper.h
+++ b/lib-agent-cpp/inc/helper.h
@@ -21,6 +21,7 @@
 #define ERR -1
 #define OK 0
 
-std::uintmax_t did_file_content(const std::string& didFilePath, std::vector<char> &buffer);
+std::uintmax_t did_file_content(const std::string& didFilePath,
+                                std::vector<char>& buffer);
 std::uintmax_t did_file_size(const std::string& didFilePath);
 #endif

--- a/lib-agent-cpp/inc/helper.h
+++ b/lib-agent-cpp/inc/helper.h
@@ -16,6 +16,7 @@
 #ifndef HELPER_H
 #define HELPER_H
 
+#include <filesystem>
 #include <vector>
 
 #define ERR -1

--- a/lib-agent-cpp/inc/helper.h
+++ b/lib-agent-cpp/inc/helper.h
@@ -16,9 +16,11 @@
 #ifndef HELPER_H
 #define HELPER_H
 
+#include <vector>
+
 #define ERR -1
 #define OK 0
 
-int did_file_content(const std::string& didFilePath, long file_size, char* buffer);
-long did_file_size(const std::string& didFilePath);
+std::uintmax_t did_file_content(const std::string& didFilePath, std::vector<char> &buffer);
+std::uintmax_t did_file_size(const std::string& didFilePath);
 #endif

--- a/lib-agent-cpp/inc/identity.h
+++ b/lib-agent-cpp/inc/identity.h
@@ -43,6 +43,16 @@ private:
 public:
     ~Identity();
     Identity();
+
+    // Disable copies, just move semantics
+    Identity(const Identity &args) = delete;
+    void operator=(const Identity&) = delete;
+
+    // declare move constructor
+    Identity(Identity &&o) noexcept;
+    // declare move assignment
+    Identity& operator=(Identity &&o) noexcept;
+
     static Identity Anonymous();
     static std::variant<Identity, std::string> BasicFromPem(const std::string& pemData);
     static std::variant<Identity, std::string> BasicFromKeyPair(const std::vector<uint8_t>& publicKey,

--- a/lib-agent-cpp/inc/identity.h
+++ b/lib-agent-cpp/inc/identity.h
@@ -17,10 +17,10 @@
 #define IDENTITY_H
 
 #include <cstdint>
-#include <iostream>
-#include <vector>
 #include <cstring>
+#include <iostream>
 #include <variant>
+#include <vector>
 
 #include "principal.h"
 
@@ -28,43 +28,46 @@ extern "C" {
 #include "zondax_ic.h"
 }
 struct IdentitySign {
-    std::vector<uint8_t> pubkey;
-    std::vector<uint8_t> signature;
+  std::vector<uint8_t> pubkey;
+  std::vector<uint8_t> signature;
 };
 
-namespace zondax::identity {
+namespace zondax {
 class Identity {
+ private:
+  void* ptr;
+  IdentityType type;
+  explicit Identity(void* ptr, IdentityType type);
 
-private:
-    void* ptr;
-    IdentityType type;
-    explicit Identity(void* ptr, IdentityType type);
+ public:
+  ~Identity();
+  Identity();
 
-public:
-    ~Identity();
-    Identity();
+  // Disable copies, just move semantics
+  Identity(const Identity& args) = delete;
+  void operator=(const Identity&) = delete;
 
-    // Disable copies, just move semantics
-    Identity(const Identity &args) = delete;
-    void operator=(const Identity&) = delete;
+  // declare move constructor
+  Identity(Identity&& o) noexcept;
+  // declare move assignment
+  Identity& operator=(Identity&& o) noexcept;
 
-    // declare move constructor
-    Identity(Identity &&o) noexcept;
-    // declare move assignment
-    Identity& operator=(Identity &&o) noexcept;
+  static Identity Anonymous();
+  static std::variant<Identity, std::string> BasicFromPem(
+      const std::string& pemData);
+  static std::variant<Identity, std::string> BasicFromKeyPair(
+      const std::vector<uint8_t>& publicKey,
+      const std::vector<uint8_t>& privateKeySeed);
+  static std::variant<Identity, std::string> Secp256k1FromPem(
+      const std::string& pemData);
+  static Identity Secp256k1FromPrivateKey(const std::vector<char>& privateKey);
+  std::variant<zondax::Principal, std::string> Sender();
+  std::variant<IdentitySign, std::string> Sign(
+      const std::vector<uint8_t>& bytes);
 
-    static Identity Anonymous();
-    static std::variant<Identity, std::string> BasicFromPem(const std::string& pemData);
-    static std::variant<Identity, std::string> BasicFromKeyPair(const std::vector<uint8_t>& publicKey,
-                                    const std::vector<uint8_t>& privateKeySeed);
-    static std::variant<Identity, std::string> Secp256k1FromPem(const std::string& pemData);
-    static Identity Secp256k1FromPrivateKey(const std::vector<char>& privateKey);
-    std::variant<zondax::principal::Principal, std::string> Sender();
-    std::variant<IdentitySign, std::string> Sign(const std::vector<uint8_t>& bytes);
-
-    void* getPtr() const;
-    IdentityType getType() const;
+  void* getPtr() const;
+  IdentityType getType() const;
 };
 
-}
+}  // namespace zondax
 #endif  // IDENTITY_H

--- a/lib-agent-cpp/inc/idl_args.h
+++ b/lib-agent-cpp/inc/idl_args.h
@@ -46,7 +46,7 @@ public:
     explicit IdlArgs(IDLArgs* argsPtr);
     explicit IdlArgs(std::string text);
     explicit IdlArgs(std::vector<uint8_t> bytes);
-    explicit IdlArgs(const std::vector<zondax::idl_value::IdlValue*>& values);
+    explicit IdlArgs(const std::vector<zondax::idl_value::IdlValue> values);
 
     std::string getText();
     std::vector<uint8_t> getBytes();
@@ -55,6 +55,9 @@ public:
     // why C++ users would want to have a pointer to an opque type?
     // it is meant to be use by us?
     IDLArgs* getPtr() const;
+
+    // void resetValue(zondax::idl_value::IdlValue &value);
+
     ~IdlArgs();
 };
 }

--- a/lib-agent-cpp/inc/idl_args.h
+++ b/lib-agent-cpp/inc/idl_args.h
@@ -32,6 +32,15 @@ private:
     IDLArgs *ptr;
 
 public:
+    // Disable copies, just move semantics
+    IdlArgs(const IdlArgs &args) = delete;
+    void operator=(const IdlArgs&) = delete;
+
+    // declare move constructor
+    IdlArgs(IdlArgs &&o) noexcept;
+    // declare move assignment
+    IdlArgs& operator=(IdlArgs &&o) noexcept;
+
     // why this constructor?
     // does this takes ownership of memory pointed by argsPtr?
     explicit IdlArgs(IDLArgs* argsPtr);

--- a/lib-agent-cpp/inc/idl_args.h
+++ b/lib-agent-cpp/inc/idl_args.h
@@ -17,50 +17,48 @@
 #define IDL_ARGS_H
 
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <vector>
-#include <cstring>
+
 #include "idl_value.h"
 
 extern "C" {
 #include "zondax_ic.h"
 }
 
-namespace zondax::idl_args {
-class IdlArgs {  
-private:
-    IDLArgs *ptr;
+namespace zondax {
+class IdlArgs {
+ private:
+  IDLArgs *ptr;
 
-public:
-    // Disable copies, just move semantics
-    IdlArgs(const IdlArgs &args) = delete;
-    void operator=(const IdlArgs&) = delete;
+ public:
+  // Disable copies, just move semantics
+  IdlArgs(const IdlArgs &args) = delete;
+  void operator=(const IdlArgs &) = delete;
 
-    // declare move constructor
-    IdlArgs(IdlArgs &&o) noexcept;
-    // declare move assignment
-    IdlArgs& operator=(IdlArgs &&o) noexcept;
+  // declare move constructor
+  IdlArgs(IdlArgs &&o) noexcept;
+  // declare move assignment
+  IdlArgs &operator=(IdlArgs &&o) noexcept;
 
-    // why this constructor?
-    // does this takes ownership of memory pointed by argsPtr?
-    explicit IdlArgs(IDLArgs* argsPtr);
-    explicit IdlArgs(std::string text);
-    explicit IdlArgs(std::vector<uint8_t> bytes);
-    explicit IdlArgs(const std::vector<zondax::idl_value::IdlValue> values);
+  // why this constructor?
+  // does this takes ownership of memory pointed by argsPtr?
+  explicit IdlArgs(IDLArgs *argsPtr);
+  explicit IdlArgs(std::string text);
+  explicit IdlArgs(std::vector<uint8_t> bytes);
+  explicit IdlArgs(const std::vector<zondax::IdlValue> values);
 
-    std::string getText();
-    std::vector<uint8_t> getBytes();
-    std::vector<zondax::idl_value::IdlValue> getVec();
-    
-    // why C++ users would want to have a pointer to an opque type?
-    // it is meant to be use by us?
-    IDLArgs* getPtr() const;
+  std::string getText();
+  std::vector<uint8_t> getBytes();
+  std::vector<zondax::IdlValue> getVec();
 
-    // void resetValue(zondax::idl_value::IdlValue &value);
+  // why C++ users would want to have a pointer to an opque type?
+  // it is meant to be use by us?
+  IDLArgs *getPtr() const;
 
-    ~IdlArgs();
+  ~IdlArgs();
 };
-}
+}  // namespace zondax
 
 #endif
-

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -17,100 +17,99 @@
 #define IDL_VALUE_H
 
 #include <cstdint>
-#include <iostream>
-#include <vector>
 #include <cstring>
-#include "principal.h"
-#include "idl_value_utils.h"
+#include <iostream>
+#include <optional>
+#include <vector>
 
+#include "idl_value_utils.h"
+#include "principal.h"
 
 extern "C" {
 #include "zondax_ic.h"
 }
 
-namespace zondax::idl_value {
+namespace zondax {
 
-class IdlValue {  
-    friend class IdlArgs;
+class IdlValue {
+  friend class IdlArgs;
 
-private:
-    IDLValue *ptr;
+ private:
+  IDLValue *ptr;
+  // this will set inner pointer to null to avoid
+  // calling destructor over it, this is useful when we
+  // sent the original this.ptr to a c function that takes
+  // ownership of passed value, so that we avoid double-free
+  // errors by reset value to nullptr
+  void resetValue();
 
-public:
+ public:
+  // Disable copies, just move semantics
+  IdlValue(const IdlValue &args) = delete;
+  void operator=(const IdlValue &) = delete;
 
-    // Disable copies, just move semantics
-    IdlValue(const IdlValue &args) = delete;
-    void operator=(const IdlValue&) = delete;
+  // declare move constructor
+  IdlValue(IdlValue &&o) noexcept;
+  // declare move assignment
+  IdlValue &operator=(IdlValue &&o) noexcept;
 
-    // declare move constructor
-    IdlValue(IdlValue &&o) noexcept;
-    // declare move assignment
-    IdlValue& operator=(IdlValue &&o) noexcept;
+  // Create IdlValues from types
+  IdlValue(IDLValue *ptr);
+  IdlValue();
+  explicit IdlValue(uint8_t val);
+  explicit IdlValue(uint16_t val);
+  explicit IdlValue(uint32_t val);
+  explicit IdlValue(uint64_t val);
+  explicit IdlValue(int8_t val);
+  explicit IdlValue(int16_t val);
+  explicit IdlValue(int32_t val);
+  explicit IdlValue(int64_t val);
+  explicit IdlValue(float val);
+  explicit IdlValue(double val);
+  explicit IdlValue(bool val);
+  explicit IdlValue(std::string text);
+  explicit IdlValue(zondax::Principal principal,
+                    bool type = true);  // true create principal false: service
+  IdlValue FromNull(void);
+  IdlValue FromNone(void);
+  IdlValue FromReserved(void);
+  IdlValue FromNumber(std::string number);
+  IdlValue FromOpt(IdlValue *value);
+  IdlValue FromVec(const std::vector<const IdlValue *> &elems);
+  IdlValue FromRecord(const std::vector<std::string> &keys,
+                      const std::vector<const IdlValue *> &elems);
+  IdlValue FromVariant(std::string key, IdlValue *val, uint64_t code);
+  IdlValue FromFunc(std::vector<uint8_t> vector, std::string func_name);
 
-    // Create IdlValues from types
-    IdlValue(IDLValue *ptr);
-    IdlValue();
-    explicit IdlValue(uint8_t val);
-    explicit IdlValue(uint16_t val);
-    explicit IdlValue(uint32_t val);
-    explicit IdlValue(uint64_t val);
-    explicit IdlValue(int8_t val);
-    explicit IdlValue(int16_t val);
-    explicit IdlValue(int32_t val);
-    explicit IdlValue(int64_t val);
-    explicit IdlValue(float val);
-    explicit IdlValue(double val);
-    explicit IdlValue(bool val);
-    explicit IdlValue(std::string text);
-    explicit IdlValue(zondax::principal::Principal principal, bool type = true); // true create principal false: service
-    IdlValue FromNull(void);
-    IdlValue FromNone(void);
-    IdlValue FromReserved(void);
-    IdlValue FromNumber(std::string number);
-    IdlValue FromOpt(IdlValue *value);
-    IdlValue FromVec(const std::vector<const IdlValue *> &elems);
-    IdlValue FromRecord(const std::vector<std::string> &keys, const std::vector<const IdlValue *> &elems);
-    IdlValue FromVariant(std::string key, IdlValue *val, uint64_t code);
-    IdlValue FromFunc(std::vector<uint8_t> vector, std::string func_name);
+  // Get types
+  bool getInt8(int8_t *val);
+  bool getInt16(int16_t *val);
+  bool getInt32(int32_t *val);
+  bool getInt64(int64_t *val);
+  bool getNat8(uint8_t *val);
+  bool getNat16(uint16_t *val);
+  bool getNat32(uint32_t *val);
+  bool getNat64(uint64_t *val);
+  bool getFloat32(float *val);
+  bool getFloat64(double *val);
+  bool getBool(bool *val);
+  std::string getText();
+  std::optional<zondax::Principal> getPrincipal();
+  std::optional<zondax::Principal> getService();
+  std::string getNumber();
+  std::optional<IdlValue> getOpt();
+  std::vector<IdlValue> getVec();
+  // zondax::idl_value_utils::Record getRecord();
+  // zondax::idl_value_utils::Variant getVariant();
+  std::optional<zondax::Func> getFunc();
 
-    // Get types
-    bool getInt8(int8_t *val);
-    bool getInt16(int16_t *val);
-    bool getInt32(int32_t *val);
-    bool getInt64(int64_t *val);
-    bool getNat8(uint8_t *val);
-    bool getNat16(uint16_t *val);
-    bool getNat32(uint32_t *val);
-    bool getNat64(uint64_t *val);
-    bool getFloat32(float *val);
-    bool getFloat64(double *val);
-    bool getBool(bool *val);
-    std::string getText();
-    zondax::principal::Principal getPrincipal();
-    zondax::principal::Principal getService();
-    std::string getNumber();
-    IdlValue getOpt();
-    std::vector<IdlValue> getVec();
-    // zondax::idl_value_utils::Record getRecord();
-    // zondax::idl_value_utils::Variant getVariant();
-    zondax::idl_value_utils::Func getFunc();
+  // methods bellow must be use carefully
+  // the first will aliase pointer, breaking move semantics only
+  // for this type if used wrong.
+  IDLValue *getPtr() const;
 
-    // methods bellow must be use carefully
-    // the first will aliase pointer, breaking move semantics only 
-    // for this type if used wrong.
-   IDLValue* getPtr() const;
-    // this will set inner pointer to null to avoid 
-    // calling destructor over it, this is useful when we 
-    // sent the original this.ptr to a c function that takes 
-    // ownership of passed value, so in order to avoid 
-    // calling the destructor after, we set it to null this.ptr = nullptr.
-    // the friend class mechanism seems to no work here 
-    // due to class forwarding, unfortunately.
-   void resetValue();
-
-   ~IdlValue();
+  ~IdlValue();
 };
-}
-
+}  // namespace zondax
 
 #endif

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -35,6 +35,16 @@ private:
     IDLValue *ptr;
 
 public:
+
+    // Disable copies, just move semantics
+    IdlValue(const IdlValue &args) = delete;
+    void operator=(const IdlValue&) = delete;
+
+    // declare move constructor
+    IdlValue(IdlValue &&o) noexcept;
+    // declare move assignment
+    IdlValue& operator=(IdlValue &&o) noexcept;
+
     // Create IdlValues from types
     IdlValue(IDLValue *ptr);
     IdlValue();

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -31,6 +31,8 @@ extern "C" {
 namespace zondax::idl_value {
 
 class IdlValue {  
+    friend class IdlArgs;
+
 private:
     IDLValue *ptr;
 
@@ -93,7 +95,19 @@ public:
     // zondax::idl_value_utils::Variant getVariant();
     zondax::idl_value_utils::Func getFunc();
 
+    // methods bellow must be use carefully
+    // the first will aliase pointer, breaking move semantics only 
+    // for this type if used wrong.
    IDLValue* getPtr() const;
+    // this will set inner pointer to null to avoid 
+    // calling destructor over it, this is useful when we 
+    // sent the original this.ptr to a c function that takes 
+    // ownership of passed value, so in order to avoid 
+    // calling the destructor after, we set it to null this.ptr = nullptr.
+    // the friend class mechanism seems to no work here 
+    // due to class forwarding, unfortunately.
+   void resetValue();
+
    ~IdlValue();
 };
 }

--- a/lib-agent-cpp/inc/idl_value_utils.h
+++ b/lib-agent-cpp/inc/idl_value_utils.h
@@ -17,35 +17,33 @@
 #define IDL_VALUE_UTILS_H
 
 #include <cstdint>
-#include <iostream>
-#include <vector>
 #include <cstring>
+#include <iostream>
 #include <memory>
+#include <vector>
 
 #include "principal.h"
-// #include "idl_value.h"
+
+namespace zondax {
 
 class IdlValue;
 
-namespace zondax::idl_value_utils {
-
-
 struct Func {
-    std::string s;
-    zondax::principal::Principal p;
+  std::string s;
+  zondax::Principal p;
 };
 
 struct Record {
-    std::vector<std::string> keys;
-    std::vector<std::unique_ptr<IdlValue *>> vals;
+  std::vector<std::string> keys;
+  std::vector<std::unique_ptr<IdlValue *>> vals;
 };
 
 struct Variant {
-    std::vector<uint8_t> id;
-    IdlValue *val;
-    uint64_t code;
+  std::vector<uint8_t> id;
+  IdlValue *val;
+  uint64_t code;
 };
 
-}// namespace
+}  // namespace zondax
 
 #endif

--- a/lib-agent-cpp/inc/principal.h
+++ b/lib-agent-cpp/inc/principal.h
@@ -32,7 +32,16 @@ class Principal {
   std::vector<unsigned char> bytes;
   CPrincipal *cPrincipal;
 
-  static void error_callback(const unsigned char *data, int len,
+/**
+* @brief Callback function for handling errors.
+*
+* @param data The error message data.
+* @param len The length of the error message data.
+* @param user_data User data for error handling.
+*
+* This function is a callback that handles errors. It is used internally in the Principal class.
+*/
+static void error_callback(const unsigned char *data, int len,
                              void *user_data);
 
  public:
@@ -40,23 +49,106 @@ class Principal {
   Principal(const Principal &args) = delete;
   void operator=(const Principal &) = delete;
 
-  // declare move constructor
-  Principal(Principal &&o) noexcept;
-  // declare move assignment
-  Principal &operator=(Principal &&o) noexcept;
+/**
+ * @brief Move constructor for Principal objects.
+ *
+ * @param o The Principal object to move.
+ *
+ * This constructor moves the content of the provided Principal object into a new Principal object.
+ */
+Principal(Principal &&o) noexcept;
 
-  explicit Principal(bool anonym = true);
-  explicit Principal(const std::vector<uint8_t> &bytes);
+/**
+* @brief Move assignment operator for Principal objects.
+*
+* @param o The Principal object to move.
+* @return Reference to the moved Principal object.
+*
+* This operator moves the content of the provided Principal object into an existing Principal object.
+*/
+Principal &operator=(Principal &&o) noexcept;
 
-  ~Principal();
+/**
+ * @brief Constructs a Principal object.
+ *
+ * @param anonym Whether the Principal should be anonymous.
+ *
+ * This constructor initializes a Principal object, either as an anonymous Principal or a management canister Principal.
+ * The `anonym` parameter determines the type of Principal to construct.
+ */
+explicit Principal(bool anonym = true);
 
-  static Principal SelfAuthenticating(const std::vector<uint8_t> &public_key);
-  static std::variant<Principal, std::string> TryFromSlice(
+/**
+ * @brief Constructs a Principal object from a vector of bytes.
+ *
+ * @param data The vector of bytes to initialize the Principal.
+ *
+ * This constructor initializes a Principal object with the provided vector of bytes.
+ * The bytes parameter contains the data used to construct the Principal.
+ */
+explicit Principal(const std::vector<uint8_t> &bytes);
+
+/**
+ * @brief Destructor for Principal objects.
+ *
+ * This destructor cleans up the memory allocated for the Principal object.
+ */
+~Principal();
+
+/**
+ * @brief Constructs a self-authenticating Principal object.
+ *
+ * @param public_key The public key used for self-authentication.
+ * @return The constructed Principal object.
+ *
+ * This function constructs a self-authenticating Principal object using the provided public key.
+ * The public key is used for self-authentication of the Principal.
+ */
+static Principal SelfAuthenticating(const std::vector<uint8_t> &public_key);
+
+/**
+ * @brief Tries to construct a Principal object from a slice of bytes.
+ *
+ * @param bytes The slice of bytes to initialize the Principal.
+ * @return Either the constructed Principal object or an error message as a string.
+ *
+ * This function tries to construct a Principal object from the provided slice of bytes.
+ * It returns either the constructed Principal object or an error message if the construction fails.
+ */
+static std::variant<Principal, std::string> TryFromSlice(
       const std::vector<uint8_t> &bytes);
-  static std::variant<Principal, std::string> FromText(const std::string &text);
-  static std::string ToText(const std::vector<uint8_t> &bytes);
 
-  std::vector<unsigned char> getBytes() const;
+/**
+ * @brief Constructs a Principal object from a text string.
+ *
+ * @param text The text string to initialize the Principal.
+ * @return Either the constructed Principal object or an error message as a string.
+ *
+ * This function constructs a Principal object from the provided text string.
+ * It returns either the constructed Principal object or an error message if the construction fails.
+ */
+static std::variant<Principal, std::string> FromText(const std::string &text);
+
+/**
+ * @brief Converts the Principal object to a text string.
+ *
+ * @param data The Principal object to convert to text.
+ * @return The text representation of the Principal object.
+ *
+ * This function converts the provided Principal object to a text string representation.
+ * It returns the resulting text representation.
+ */
+static std::string ToText(const std::vector<uint8_t> &bytes);
+
+/**
+ * @brief Retrieves the bytes of the Principal object.
+ *
+ * @return The bytes of the Principal object.
+ *
+ * This function returns the bytes of the Principal object as a vector of unsigned characters.
+ */
+std::vector<unsigned char> getBytes() const;
+
 };
 
 }  // namespace zondax

--- a/lib-agent-cpp/inc/principal.h
+++ b/lib-agent-cpp/inc/principal.h
@@ -34,6 +34,15 @@ private:
     CPrincipal* cPrincipal;
 
 public:
+    // Disable copies, just move semantics
+    Principal(const Principal &args) = delete;
+    void operator=(const Principal&) = delete;
+
+    // declare move constructor
+    Principal(Principal &&o) noexcept;
+    // declare move assignment
+    Principal& operator=(Principal &&o) noexcept;
+
     explicit Principal(bool anonym = true);
     explicit Principal(const std::vector<uint8_t> &bytes);
 

--- a/lib-agent-cpp/inc/principal.h
+++ b/lib-agent-cpp/inc/principal.h
@@ -17,43 +17,47 @@
 #define PRINCIPAL_H
 
 #include <cstdint>
-#include <iostream>
-#include <vector>
 #include <cstring>
+#include <iostream>
 #include <variant>
-
+#include <vector>
 
 extern "C" {
 #include "zondax_ic.h"
 }
 
-namespace zondax::principal {
+namespace zondax {
 class Principal {
-private:
-    std::vector<unsigned char> bytes;
-    CPrincipal* cPrincipal;
+ private:
+  std::vector<unsigned char> bytes;
+  CPrincipal *cPrincipal;
 
-public:
-    // Disable copies, just move semantics
-    Principal(const Principal &args) = delete;
-    void operator=(const Principal&) = delete;
+  static void error_callback(const unsigned char *data, int len,
+                             void *user_data);
 
-    // declare move constructor
-    Principal(Principal &&o) noexcept;
-    // declare move assignment
-    Principal& operator=(Principal &&o) noexcept;
+ public:
+  // Disable copies, just move semantics
+  Principal(const Principal &args) = delete;
+  void operator=(const Principal &) = delete;
 
-    explicit Principal(bool anonym = true);
-    explicit Principal(const std::vector<uint8_t> &bytes);
+  // declare move constructor
+  Principal(Principal &&o) noexcept;
+  // declare move assignment
+  Principal &operator=(Principal &&o) noexcept;
 
-    static Principal SelfAuthenticating(const std::vector<uint8_t> &public_key);
-    static std::variant<Principal, std::string>  TryFromSlice(const std::vector<uint8_t> &bytes);
-    static std::variant<Principal, std::string>   FromText(const std::string& text);
-    static std::string ToText(const std::vector<uint8_t> &bytes);
+  explicit Principal(bool anonym = true);
+  explicit Principal(const std::vector<uint8_t> &bytes);
 
-    std::vector<unsigned char> getBytes() const;
-    ~Principal();
+  ~Principal();
+
+  static Principal SelfAuthenticating(const std::vector<uint8_t> &public_key);
+  static std::variant<Principal, std::string> TryFromSlice(
+      const std::vector<uint8_t> &bytes);
+  static std::variant<Principal, std::string> FromText(const std::string &text);
+  static std::string ToText(const std::vector<uint8_t> &bytes);
+
+  std::vector<unsigned char> getBytes() const;
 };
 
-}
+}  // namespace zondax
 #endif  // PRINCIPAL_H

--- a/lib-agent-cpp/src/agent.cpp
+++ b/lib-agent-cpp/src/agent.cpp
@@ -80,7 +80,7 @@ std::variant<Agent, std::string> Agent::create_agent(std::string url, zondax::id
 }
 
 std::variant<IdlArgs, std::string> Agent::Query(std::string service,
-                                        zondax::idl_args::IdlArgs args) {
+                                        zondax::idl_args::IdlArgs &args) {
 
     CText *arg = idl_args_to_text(args.getPtr());
 

--- a/lib-agent-cpp/src/agent.cpp
+++ b/lib-agent-cpp/src/agent.cpp
@@ -96,9 +96,9 @@ std::variant<IdlArgs, std::string> Agent::Query(std::string service,
         return error;
     }
 
-    IdlArgs result(argsPtr);
+    // IdlArgs result(argsPtr);
 
-    std::variant<IdlArgs, std::string> ok(result);
+    std::variant<IdlArgs, std::string> ok{std::in_place_type<IdlArgs>, argsPtr};
 
     return ok;
 }
@@ -120,8 +120,7 @@ std::variant<IdlArgs, std::string> Agent::Update(std::string service,
         return error;
     }
 
-    IdlArgs result(argsPtr);
-    std::variant<IdlArgs, std::string> ok(result);
+    std::variant<IdlArgs, std::string> ok{std::in_place_type<IdlArgs>, argsPtr};
 
     return ok;
 }

--- a/lib-agent-cpp/src/agent.cpp
+++ b/lib-agent-cpp/src/agent.cpp
@@ -14,120 +14,133 @@
  *  limitations under the License.
  ********************************************************************************/
 
-#include <utility>
 #include "agent.h"
 
-using zondax::idl_args::IdlArgs;
+#include <utility>
 
-namespace zondax::agent {
+using zondax::IdlArgs;
 
-void error_callback(const unsigned char *data, int len, void *user_data) {
-    std::string error_msg((const char *)data, len);
-    *(std::string *)user_data = error_msg;
+namespace zondax {
+
+void Agent::error_callback(const unsigned char* data, int len,
+                           void* user_data) {
+  std::string error_msg((const char*)data, len);
+  *(std::string*)user_data = error_msg;
 }
 
 // declare move constructor
-Agent::Agent(Agent &&o) noexcept {
-    agent = o.agent;
-    o.agent = nullptr;
-} 
-
-// declare move assignment
-Agent& Agent::operator=(Agent &&o) noexcept {
-    // check they are not the same object
-    if (&o == this)
-        return *this;
-
-    // now release our inner agent.
-    if (agent != nullptr)
-        agent_destroy(agent);
-
-    // now takes ownership of the o.agent 
-    agent = o.agent;
-
-    // ensure o.agent is null 
-    o.agent = nullptr;
-
-    return *this;
+Agent::Agent(Agent&& o) noexcept {
+  agent = o.agent;
+  o.agent = nullptr;
 }
 
-std::variant<Agent, std::string> Agent::create_agent(std::string url, zondax::identity::Identity id, zondax::principal::Principal principal,
-                const std::vector<char>& did_content) {
+// declare move assignment
+Agent& Agent::operator=(Agent&& o) noexcept {
+  // check they are not the same object
+  if (&o == this) return *this;
 
-        // string to get error message from callback
-        std::string data;
+  // now release our inner agent.
+  if (agent != nullptr) agent_destroy(agent);
 
-        RetError ret;
-        ret.user_data = (void *)&data;
-        ret.call = error_callback;
+  // now takes ownership of the o.agent
+  agent = o.agent;
 
-        
-        FFIAgent* c_agent = agent_create_wrap(url.c_str(), id.getPtr(), id.getType(), principal.getBytes().data(), principal.getBytes().size(), did_content.data(), &ret);
+  // ensure o.agent is null
+  o.agent = nullptr;
 
-        if (c_agent == nullptr) {
-            std::variant<Agent, std::string> error(data);
-            return error;
-        }
-        
-        // here we can use private default constructor, but users can't, also if default were disabled using the delete keyboard, we 
-        // would not be able to use it here.
-        auto cpp_agent = Agent();
+  return *this;
+}
 
-        cpp_agent.agent = c_agent;
-        std::variant<Agent, std::string> ok(std::move(cpp_agent));
+std::variant<Agent, std::string> Agent::create_agent(
+    std::string url, zondax::Identity id, zondax::Principal principal,
+    const std::vector<char>& did_content) {
+  // string to get error message from callback
+  std::string data;
 
-        return ok;
+  RetError ret;
+  ret.user_data = (void*)&data;
+  ret.call = Agent::error_callback;
+
+  FFIAgent* c_agent = agent_create_wrap(
+      url.c_str(), id.getPtr(), id.getType(), principal.getBytes().data(),
+      principal.getBytes().size(), did_content.data(), &ret);
+
+  if (c_agent == nullptr) {
+    std::variant<Agent, std::string> error(data);
+    return error;
+  }
+
+  // here we can use private default constructor, but users can't, also if
+  // default were disabled using the delete keyboard, we would not be able to
+  // use it here.
+  auto cpp_agent = Agent();
+
+  cpp_agent.agent = c_agent;
+  std::variant<Agent, std::string> ok(std::move(cpp_agent));
+
+  return ok;
 }
 
 std::variant<IdlArgs, std::string> Agent::Query(std::string service,
-                                        zondax::idl_args::IdlArgs &args) {
+                                                zondax::IdlArgs& args) {
+  if (agent == nullptr) {
+    std::variant<IdlArgs, std::string> error{std::in_place_type<std::string>,
+                                             "Agent instance uninitialized"};
+    return error;
+  }
 
-    CText *arg = idl_args_to_text(args.getPtr());
+  CText* arg = idl_args_to_text(args.getPtr());
 
-    RetError ret;
-    std::string data;
-    ret.user_data = (void *)&data;
-    ret.call = error_callback;
+  RetError ret;
+  std::string data;
+  ret.user_data = (void*)&data;
+  ret.call = Agent::error_callback;
 
-    IDLArgs* argsPtr = agent_query_wrap(agent, service.c_str(), ctext_str(arg), &ret);
+  IDLArgs* argsPtr =
+      agent_query_wrap(agent, service.c_str(), ctext_str(arg), &ret);
 
-    if (argsPtr == nullptr) {
-        std::variant<IdlArgs, std::string> error(data);
-        return error;
-    }
+  if (argsPtr == nullptr) {
+    std::variant<IdlArgs, std::string> error(data);
+    return error;
+  }
 
-    // IdlArgs result(argsPtr);
+  // IdlArgs result(argsPtr);
 
-    std::variant<IdlArgs, std::string> ok{std::in_place_type<IdlArgs>, argsPtr};
+  std::variant<IdlArgs, std::string> ok{std::in_place_type<IdlArgs>, argsPtr};
 
-    return ok;
+  return ok;
 }
 
 std::variant<IdlArgs, std::string> Agent::Update(std::string service,
-                                        zondax::idl_args::IdlArgs args){
+                                                 zondax::IdlArgs& args) {
+  if (agent == nullptr) {
+    std::variant<IdlArgs, std::string> error{std::in_place_type<std::string>,
+                                             "Agent instance uninitialized"};
+    return error;
+  }
 
-    CText *arg = idl_args_to_text(args.getPtr());
+  CText* arg = idl_args_to_text(args.getPtr());
 
-    RetError ret;
-    std::string data;
-    ret.user_data = (void *)&data;
-    ret.call = error_callback;
+  RetError ret;
+  std::string data;
+  ret.user_data = (void*)&data;
+  ret.call = Agent::error_callback;
 
-    IDLArgs* argsPtr = agent_update_wrap(agent, service.c_str(), ctext_str(arg), &ret);
+  IDLArgs* argsPtr =
+      agent_update_wrap(agent, service.c_str(), ctext_str(arg), &ret);
 
-    if (argsPtr == nullptr) {
-        std::variant<IdlArgs, std::string> error(data);
-        return error;
-    }
+  if (argsPtr == nullptr) {
+    std::variant<IdlArgs, std::string> error(data);
+    return error;
+  }
 
-    std::variant<IdlArgs, std::string> ok{std::in_place_type<IdlArgs>, argsPtr};
+  std::variant<IdlArgs, std::string> ok{std::in_place_type<IdlArgs>, argsPtr};
 
-    return ok;
+  return ok;
 }
 
-Agent::~Agent(){
-    if (agent != nullptr)
-        agent_destroy(agent);
+Agent::~Agent() {
+  if (agent != nullptr) agent_destroy(agent);
 }
 
-}
+}  // namespace zondax

--- a/lib-agent-cpp/src/helper.cpp
+++ b/lib-agent-cpp/src/helper.cpp
@@ -15,34 +15,34 @@
  ********************************************************************************/
 #include <iostream>
 #include <fstream>
-#include <vector>
+#include <filesystem>
+
 #include "helper.h"
 
-int did_file_content(const std::string& didFilePath, long file_size, char* buffer) {
-    std::ifstream file(didFilePath, std::ios::binary);
-    if (!file) {
-        return -1;  // error opening file
+std::uintmax_t did_file_content(const std::string& didFilePath, std::vector<char> &outBuf) {
+    auto file_size = did_file_size(didFilePath);
+
+    if ( file_size > 0 ) {
+        outBuf.resize(file_size);
     }
 
-    // Read the file contents into the buffer
-    file.read(buffer, file_size);
-    buffer[file_size] = '\0';
+    std::ifstream file(didFilePath, std::ios::binary);
 
-    // Close the file and return the buffer
+    file.read(&outBuf[0], file_size);
+
+    if(!file) {
+        std::cerr << "Error reading file: "<<didFilePath << " \ncould only read: " << file.gcount() << " bytes" << std::endl;
+        return 0;
+    }
+    
+    auto read = file.gcount();
+
     file.close();
-    return 0;
+
+    return read; 
 }
 
-long did_file_size(const std::string& didFilePath) {
-    std::ifstream file(didFilePath, std::ios::binary | std::ios::ate);
-    if (!file) {
-        return 0;  // error opening file
-    }
-
-    // Get the file size
-    long file_size = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    file.close();
-    return file_size + 1;
+std::uintmax_t did_file_size(const std::string& didFilePath) {
+    std::uintmax_t filesize = std::filesystem::file_size(didFilePath);
+    return filesize;
 }

--- a/lib-agent-cpp/src/helper.cpp
+++ b/lib-agent-cpp/src/helper.cpp
@@ -15,7 +15,6 @@
  ********************************************************************************/
 #include "helper.h"
 
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 

--- a/lib-agent-cpp/src/helper.cpp
+++ b/lib-agent-cpp/src/helper.cpp
@@ -13,36 +13,39 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-#include <iostream>
-#include <fstream>
-#include <filesystem>
-
 #include "helper.h"
 
-std::uintmax_t did_file_content(const std::string& didFilePath, std::vector<char> &outBuf) {
-    auto file_size = did_file_size(didFilePath);
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 
-    if ( file_size > 0 ) {
-        outBuf.resize(file_size);
-    }
+std::uintmax_t did_file_content(const std::string& didFilePath,
+                                std::vector<char>& outBuf) {
+  auto file_size = did_file_size(didFilePath);
 
-    std::ifstream file(didFilePath, std::ios::binary);
+  if (file_size > 0) {
+    outBuf.resize(file_size);
+  }
 
-    file.read(&outBuf[0], file_size);
+  std::ifstream file(didFilePath, std::ios::binary);
 
-    if(!file) {
-        std::cerr << "Error reading file: "<<didFilePath << " \ncould only read: " << file.gcount() << " bytes" << std::endl;
-        return 0;
-    }
-    
-    auto read = file.gcount();
+  file.read(&outBuf[0], file_size);
 
-    file.close();
+  if (!file) {
+    std::cerr << "Error reading file: " << didFilePath
+              << " \ncould only read: " << file.gcount() << " bytes"
+              << std::endl;
+    return 0;
+  }
 
-    return read; 
+  auto read = file.gcount();
+
+  file.close();
+
+  return read;
 }
 
 std::uintmax_t did_file_size(const std::string& didFilePath) {
-    std::uintmax_t filesize = std::filesystem::file_size(didFilePath);
-    return filesize;
+  std::uintmax_t filesize = std::filesystem::file_size(didFilePath);
+  return filesize;
 }

--- a/lib-agent-cpp/src/identity.cpp
+++ b/lib-agent-cpp/src/identity.cpp
@@ -22,6 +22,34 @@ namespace zondax::identity {
         *(std::string *)user_data = error_msg;
     }
 
+    // declare move constructor
+    Identity::Identity(Identity &&o) noexcept {
+        ptr = o.ptr;
+        type = o.type; 
+        o.ptr = nullptr;
+    } 
+
+    // declare move assignment
+    Identity& Identity::operator=(Identity &&o) noexcept {
+        // check they are not the same object
+        if (&o == this)
+            return *this;
+
+        // now release our inner identity.
+        if (ptr != nullptr)
+            // identity_destroy(ptr);
+
+        // now takes ownership of the o.agent 
+        ptr = o.ptr;
+        type = o.type;
+
+        // ensure o.agent is null 
+        o.ptr = nullptr;
+
+
+        return *this;
+    }
+
 
     Identity::Identity(void* ptr, IdentityType type) : ptr(ptr), type(type) {}
 
@@ -159,6 +187,7 @@ namespace zondax::identity {
         return type;
     }
 
+    // TODO: what function to call for identity destruction?
     Identity::~Identity() {}
 }
 

--- a/lib-agent-cpp/src/identity.cpp
+++ b/lib-agent-cpp/src/identity.cpp
@@ -15,176 +15,192 @@
  ********************************************************************************/
 #include "identity.h"
 
-namespace zondax::identity {
+namespace zondax {
 
-    void error_callback(const unsigned char *data, int len, void *user_data) {
-        std::string error_msg((const char *)data, len);
-        *(std::string *)user_data = error_msg;
-    }
-
-    // declare move constructor
-    Identity::Identity(Identity &&o) noexcept: ptr(o.ptr), type(o.type) {
-        o.ptr = nullptr;
-    } 
-
-    // declare move assignment
-    Identity& Identity::operator=(Identity &&o) noexcept {
-        // check they are not the same object
-        if (&o == this)
-            return *this;
-
-        // now release our inner identity.
-        if (ptr != nullptr)
-            // identity_destroy(ptr);
-
-        // now takes ownership of pointer
-        ptr = o.ptr;
-        type = o.type;
-
-        // ensure o.ptr is null 
-        o.ptr = nullptr;
-
-        return *this;
-    }
-
-
-    Identity::Identity(void* ptr, IdentityType type) : ptr(ptr), type(type) {}
-
-    Identity::Identity() {
-        ptr = identity_anonymous();
-        type = IdentityType::Anonym;
-    }
-
-    std::variant<Identity, std::string> Identity::BasicFromPem(const std::string& pemData) {
-        // string to get error message from callback
-        std::string data;
-
-        RetError ret;
-        ret.user_data = (void *)&data;
-        ret.call = error_callback;
-
-        void* ptr = identity_basic_from_pem(pemData.data(), &ret);
-        
-        if (ptr == nullptr) {
-            std::variant<Identity, std::string> error(data);
-            return error;
-        }
-
-        std::variant<Identity, std::string> ok(std::move(Identity(ptr, IdentityType::Basic)));
-        // return Identity(ptr, IdentityType::Basic);
-        return ok;
-    }
-
-    std::variant<Identity, std::string> Identity::Secp256k1FromPem(const std::string& pemData) {
-        // string to get error message from callback
-        std::string data;
-
-        RetError ret;
-        ret.user_data = (void *)&data;
-        ret.call = error_callback;
-
-        void* ptr = identity_secp256k1_from_pem(pemData.data(), &ret);
-
-        if (ptr == nullptr) {
-            std::variant<Identity, std::string> error(data);
-            return error;
-        }
-
-        std::variant<Identity, std::string> ok(std::move(Identity(ptr, IdentityType::Secp256k1)));
-        // return Identity(ptr, IdentityType::Secp256k1);
-        return ok;
-    }
-
-    std::variant<Identity, std::string> Identity::BasicFromKeyPair(const std::vector<uint8_t>& publicKey,
-                                     const std::vector<uint8_t>& privateKeySeed) {
-        // string to get error message from callback
-        std::string data;
-
-        RetError ret;
-        ret.user_data = (void *)&data;
-        ret.call = error_callback;
-
-        void *ptr = identity_basic_from_key_pair(publicKey.data(), privateKeySeed.data(), &ret);
-        
-        if (ptr == nullptr) {
-            std::variant<Identity, std::string> error(data);
-            return error;
-        }
-
-        std::variant<Identity, std::string> ok(std::move(Identity(ptr, IdentityType::Basic)));
-        // return Identity(ptr, IdentityType::Basic);
-        return ok;
-    }
-
-    Identity Identity::Secp256k1FromPrivateKey(const std::vector<char>& privateKey) {
-        void *ptr = identity_secp256k1_from_private_key(privateKey.data(), privateKey.size());
-        
-        return Identity(ptr, IdentityType::Basic);
-    }
-
-    std::variant<zondax::principal::Principal, std::string> Identity::Sender() {
-        // string to get error message from callback
-        std::string data;
-
-        RetError ret;
-        ret.user_data = (void *)&data;
-        ret.call = error_callback;
-
-        CPrincipal *p = identity_sender(ptr, type, &ret);
-
-        if (p == nullptr) {
-            std::variant<zondax::principal::Principal, std::string> error(data);
-            return error;
-        }
-
-        std::vector<unsigned char> outBytes(p->ptr, p->ptr + p->len);
-        ptr = nullptr;
-
-        auto principal = zondax::principal::Principal(outBytes);
-
-        std::variant<zondax::principal::Principal, std::string> ok(std::move(principal));
-
-        return ok;
-    }
-
-    std::variant<IdentitySign, std::string> Identity::Sign(const std::vector<uint8_t>& bytes) {
-        // string to get error message from callback
-        std::string data;
-
-        RetError ret;
-        ret.user_data = (void *)&data;
-        ret.call = error_callback;
-
-        CIdentitySign* p = identity_sign(bytes.data(), bytes.size(), ptr, type, &ret);
-
-        if (p == nullptr) {
-            std::variant<IdentitySign, std::string> error(data);
-            return error;
-        }
-
-        IdentitySign result;
-
-        std::vector<unsigned char> pk(cidentitysign_pubkey(p), cidentitysign_pubkey(p) + cidentitysign_pubkey_len(p));
-        std::vector<unsigned char> sig(cidentitysign_sig(p), cidentitysign_sig(p) + cidentitysign_sig_len(p));
-
-        result.pubkey = pk;
-        result.signature = sig;
-        cidentitysign_destroy(p);
-
-        std::variant<IdentitySign, std::string> ok(std::move(result));
-
-        return result;
-    }
-
-    void* Identity::getPtr() const {
-        return ptr;
-    }
-
-    IdentityType Identity::getType() const {
-        return type;
-    }
-
-    // TODO: what function to call for identity destruction?
-    Identity::~Identity() {}
+void error_callback(const unsigned char *data, int len, void *user_data) {
+  std::string error_msg((const char *)data, len);
+  *(std::string *)user_data = error_msg;
 }
 
+// declare move constructor
+Identity::Identity(Identity &&o) noexcept : ptr(o.ptr), type(o.type) {
+  o.ptr = nullptr;
+}
+
+// declare move assignment
+Identity &Identity::operator=(Identity &&o) noexcept {
+  // check they are not the same object
+  if (&o == this) return *this;
+
+  // now release our inner identity.
+  if (ptr != nullptr)
+    // identity_destroy(ptr);
+
+    // now takes ownership of pointer
+    ptr = o.ptr;
+  type = o.type;
+
+  // ensure o.ptr is null
+  o.ptr = nullptr;
+
+  return *this;
+}
+
+Identity::Identity(void *ptr, IdentityType type) : ptr(ptr), type(type) {}
+
+Identity::Identity() {
+  ptr = identity_anonymous();
+  type = IdentityType::Anonym;
+}
+
+std::variant<Identity, std::string> Identity::BasicFromPem(
+    const std::string &pemData) {
+  // string to get error message from callback
+  std::string data;
+
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = error_callback;
+
+  void *ptr = identity_basic_from_pem(pemData.data(), &ret);
+
+  if (ptr == nullptr) {
+    std::variant<Identity, std::string> error(data);
+    return error;
+  }
+
+  std::variant<Identity, std::string> ok(
+      std::move(Identity(ptr, IdentityType::Basic)));
+
+  return ok;
+}
+
+std::variant<Identity, std::string> Identity::Secp256k1FromPem(
+    const std::string &pemData) {
+  // string to get error message from callback
+  std::string data;
+
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = error_callback;
+
+  void *ptr = identity_secp256k1_from_pem(pemData.data(), &ret);
+
+  if (ptr == nullptr) {
+    std::variant<Identity, std::string> error(data);
+    return error;
+  }
+
+  std::variant<Identity, std::string> ok(
+      std::move(Identity(ptr, IdentityType::Secp256k1)));
+  return ok;
+}
+
+std::variant<Identity, std::string> Identity::BasicFromKeyPair(
+    const std::vector<uint8_t> &publicKey,
+    const std::vector<uint8_t> &privateKeySeed) {
+  // string to get error message from callback
+  std::string data;
+
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = error_callback;
+
+  void *ptr = identity_basic_from_key_pair(publicKey.data(),
+                                           privateKeySeed.data(), &ret);
+
+  if (ptr == nullptr) {
+    std::variant<Identity, std::string> error(data);
+    return error;
+  }
+
+  std::variant<Identity, std::string> ok(
+      std::move(Identity(ptr, IdentityType::Basic)));
+
+  return ok;
+}
+
+Identity Identity::Secp256k1FromPrivateKey(
+    const std::vector<char> &privateKey) {
+  void *ptr =
+      identity_secp256k1_from_private_key(privateKey.data(), privateKey.size());
+
+  return Identity(ptr, IdentityType::Basic);
+}
+
+std::variant<zondax::Principal, std::string> Identity::Sender() {
+  if (ptr == nullptr) {
+    std::variant<Principal, std::string> error{
+        std::in_place_type<std::string>, "Identity instance uninitialized"};
+    return error;
+  }
+
+  // string to get error message from callback
+  std::string data;
+
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = error_callback;
+
+  CPrincipal *p = identity_sender(ptr, type, &ret);
+
+  if (p == nullptr) {
+    std::variant<zondax::Principal, std::string> error(data);
+    return error;
+  }
+
+  std::vector<unsigned char> outBytes(p->ptr, p->ptr + p->len);
+  ptr = nullptr;
+
+  auto principal = zondax::Principal(outBytes);
+
+  std::variant<zondax::Principal, std::string> ok(std::move(principal));
+
+  return ok;
+}
+
+std::variant<IdentitySign, std::string> Identity::Sign(
+    const std::vector<uint8_t> &bytes) {
+  if (ptr == nullptr) {
+    std::variant<IdentitySign, std::string> error{
+        std::in_place_type<std::string>, "Identity instance uninitialized"};
+    return error;
+  }
+  // string to get error message from callback
+  std::string data;
+
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = error_callback;
+
+  CIdentitySign *p = identity_sign(bytes.data(), bytes.size(), ptr, type, &ret);
+
+  if (p == nullptr) {
+    std::variant<IdentitySign, std::string> error(data);
+    return error;
+  }
+
+  IdentitySign result;
+
+  std::vector<unsigned char> pk(
+      cidentitysign_pubkey(p),
+      cidentitysign_pubkey(p) + cidentitysign_pubkey_len(p));
+  std::vector<unsigned char> sig(
+      cidentitysign_sig(p), cidentitysign_sig(p) + cidentitysign_sig_len(p));
+
+  result.pubkey = pk;
+  result.signature = sig;
+  cidentitysign_destroy(p);
+
+  std::variant<IdentitySign, std::string> ok(std::move(result));
+
+  return result;
+}
+
+void *Identity::getPtr() const { return ptr; }
+
+IdentityType Identity::getType() const { return type; }
+
+// TODO: what function to call for identity destruction?
+Identity::~Identity() {}
+}  // namespace zondax

--- a/lib-agent-cpp/src/identity.cpp
+++ b/lib-agent-cpp/src/identity.cpp
@@ -23,9 +23,7 @@ namespace zondax::identity {
     }
 
     // declare move constructor
-    Identity::Identity(Identity &&o) noexcept {
-        ptr = o.ptr;
-        type = o.type; 
+    Identity::Identity(Identity &&o) noexcept: ptr(o.ptr), type(o.type) {
         o.ptr = nullptr;
     } 
 
@@ -39,13 +37,12 @@ namespace zondax::identity {
         if (ptr != nullptr)
             // identity_destroy(ptr);
 
-        // now takes ownership of the o.agent 
+        // now takes ownership of pointer
         ptr = o.ptr;
         type = o.type;
 
-        // ensure o.agent is null 
+        // ensure o.ptr is null 
         o.ptr = nullptr;
-
 
         return *this;
     }

--- a/lib-agent-cpp/src/identity.cpp
+++ b/lib-agent-cpp/src/identity.cpp
@@ -33,11 +33,10 @@ Identity &Identity::operator=(Identity &&o) noexcept {
   if (&o == this) return *this;
 
   // now release our inner identity.
-  if (ptr != nullptr)
-    // identity_destroy(ptr);
+  if (ptr != nullptr) identity_destroy(ptr, type);
 
-    // now takes ownership of pointer
-    ptr = o.ptr;
+  // now takes ownership of pointer
+  ptr = o.ptr;
   type = o.type;
 
   // ensure o.ptr is null
@@ -201,6 +200,7 @@ void *Identity::getPtr() const { return ptr; }
 
 IdentityType Identity::getType() const { return type; }
 
-// TODO: what function to call for identity destruction?
-Identity::~Identity() {}
+Identity::~Identity() {
+  if (ptr != nullptr) identity_destroy(ptr, type);
+}
 }  // namespace zondax

--- a/lib-agent-cpp/src/idl_args.cpp
+++ b/lib-agent-cpp/src/idl_args.cpp
@@ -29,14 +29,11 @@ IdlArgs& IdlArgs::operator=(IdlArgs &&o) noexcept {
     if (&o == this)
         return *this;
 
-    // now release our inner identity.
     if (ptr != nullptr)
         idl_args_destroy(ptr);
 
-    // now takes ownership of the o.agent 
     ptr = o.ptr;
 
-    // ensure o.agent is null 
     o.ptr = nullptr;
 
     return *this;

--- a/lib-agent-cpp/src/idl_args.cpp
+++ b/lib-agent-cpp/src/idl_args.cpp
@@ -82,6 +82,7 @@ IDLArgs* IdlArgs::getPtr() const{
 }
 
 IdlArgs::~IdlArgs() {
-    idl_args_destroy(ptr); // Call the destroy function
+    if (ptr != nullptr)
+        idl_args_destroy(ptr);
 }
 }

--- a/lib-agent-cpp/src/idl_args.cpp
+++ b/lib-agent-cpp/src/idl_args.cpp
@@ -15,100 +15,102 @@
  ********************************************************************************/
 #include "idl_args.h"
 
-namespace zondax::idl_args {
+namespace zondax {
 
 // declare move constructor
-IdlArgs::IdlArgs(IdlArgs &&o) noexcept {
-    ptr = o.ptr;
-    o.ptr = nullptr;
-} 
-
-// declare move assignment
-IdlArgs& IdlArgs::operator=(IdlArgs &&o) noexcept {
-    // check they are not the same object
-    if (&o == this)
-        return *this;
-
-    if (ptr != nullptr)
-        idl_args_destroy(ptr);
-
-    ptr = o.ptr;
-
-    o.ptr = nullptr;
-
-    return *this;
+IdlArgs::IdlArgs(IdlArgs&& o) noexcept {
+  ptr = o.ptr;
+  o.ptr = nullptr;
 }
 
+// declare move assignment
+IdlArgs& IdlArgs::operator=(IdlArgs&& o) noexcept {
+  // check they are not the same object
+  if (&o == this) return *this;
 
-IdlArgs::IdlArgs(IDLArgs* argsPtr) : ptr(argsPtr) {};
+  if (ptr != nullptr) idl_args_destroy(ptr);
 
-IdlArgs::IdlArgs(std::vector<zondax::idl_value::IdlValue> values) {
-    ptr = empty_idl_args();
-    // Convert vector of IdlValue pointers to an array of const pointers
-    for (int i=0; i<values.size(); ++i) {
-        // pass value.ptr to rust, note that rust takes ownership of it.
-        idl_args_push_value(ptr, values[i].getPtr());
-        // set this ptr alias that now is pointed to memory owned by rust,
-        // to nullptr, so that at the end of this scope, the destructor 
-        // would see it is null, avoiding a potential double-free error.
-        values[i].resetValue();
-    }
+  ptr = o.ptr;
+
+  o.ptr = nullptr;
+
+  return *this;
+}
+
+IdlArgs::IdlArgs(IDLArgs* argsPtr) : ptr(argsPtr){};
+
+IdlArgs::IdlArgs(std::vector<zondax::IdlValue> values) {
+  ptr = empty_idl_args();
+  // Convert vector of IdlValue pointers to an array of const pointers
+  for (int i = 0; i < values.size(); ++i) {
+    // pass value.ptr to rust, note that rust takes ownership of it.
+    idl_args_push_value(ptr, values[i].getPtr());
+    // set this ptr alias that now is pointed to memory owned by rust,
+    // to nullptr, so that at the end of this scope, the destructor
+    // would see it is null, avoiding a potential double-free error.
+    values[i].resetValue();
+  }
 }
 
 IdlArgs::IdlArgs(std::vector<uint8_t> bytes) {
-    ptr = idl_args_from_bytes(bytes.data(), bytes.size(), nullptr);
+  ptr = idl_args_from_bytes(bytes.data(), bytes.size(), nullptr);
 }
 
 IdlArgs::IdlArgs(std::string text) {
-    ptr = idl_args_from_text(text.c_str(), nullptr);
+  ptr = idl_args_from_text(text.c_str(), nullptr);
 }
 
 std::string IdlArgs::getText() {
-    CText* cText = idl_args_to_text(ptr);
-    const char* str = ctext_str(cText);
-    uintptr_t len = ctext_len(cText);
+  CText* cText = idl_args_to_text(ptr);
+  const char* str = ctext_str(cText);
+  uintptr_t len = ctext_len(cText);
 
-    std::string text(str, len);
-    // Free the allocated CText
-    ctext_destroy(cText);
-    return text;
+  std::string text(str, len);
+  // Free the allocated CText
+  ctext_destroy(cText);
+  return text;
 }
 
 std::vector<uint8_t> IdlArgs::getBytes() {
+  if (ptr == nullptr) {
+    std::cerr << "IDLArgs instance uninitialized" << std::endl;
+    return std::vector<uint8_t>();
+  }
 
-    // TODO: Remove null and use proper callback if needed
-    CBytes* cBytes = idl_args_to_bytes(ptr, nullptr);
-    const uint8_t* byte = cbytes_ptr(cBytes);
-    uintptr_t len = cbytes_len(cBytes);
+  // TODO: Remove null and use proper callback if needed
+  CBytes* cBytes = idl_args_to_bytes(ptr, nullptr);
+  const uint8_t* byte = cbytes_ptr(cBytes);
+  uintptr_t len = cbytes_len(cBytes);
 
-    std::vector<uint8_t> bytes(byte, byte + len);
-    // Free the allocated CText
-    cbytes_destroy(cBytes);
-    return bytes;
+  std::vector<uint8_t> bytes(byte, byte + len);
+  // Free the allocated CText
+  cbytes_destroy(cBytes);
+  return bytes;
 }
 
-std::vector<zondax::idl_value::IdlValue> IdlArgs::getVec() {
-    CIDLValuesVec* cVec = idl_args_to_vec(ptr);
-    std::vector<zondax::idl_value::IdlValue> vec;
+std::vector<zondax::IdlValue> IdlArgs::getVec() {
+  if (ptr == nullptr) {
+    std::cerr << "IDLArgs instance uninitialized" << std::endl;
+    return std::vector<zondax::IdlValue>();
+  }
 
-    for (uintptr_t i = 0; i < cidlval_vec_len(cVec); ++i) {
-        const IDLValue* idlValue = cidlval_vec_value(cVec, i);
-        vec.push_back(zondax::idl_value::IdlValue(idlValue));
+  CIDLValuesVec* cVec = idl_args_to_vec(ptr);
+  std::vector<zondax::IdlValue> vec;
 
-    }
+  for (uintptr_t i = 0; i < cidlval_vec_len(cVec); ++i) {
+    const IDLValue* idlValue = cidlval_vec_value(cVec, i);
+    vec.push_back(zondax::IdlValue(idlValue));
+  }
 
-    // Free the allocated CIDLValuesVec
-    cidlval_vec_destroy(cVec);
-    return vec;
+  // Free the allocated CIDLValuesVec
+  cidlval_vec_destroy(cVec);
+  return vec;
 }
 
-IDLArgs* IdlArgs::getPtr() const{
-    return ptr;
-}
+IDLArgs* IdlArgs::getPtr() const { return ptr; }
 
 IdlArgs::~IdlArgs() {
-    if (ptr != nullptr)
-        idl_args_destroy(ptr);
+  if (ptr != nullptr) idl_args_destroy(ptr);
 }
 
-}
+}  // namespace zondax

--- a/lib-agent-cpp/src/idl_args.cpp
+++ b/lib-agent-cpp/src/idl_args.cpp
@@ -17,6 +17,32 @@
 
 namespace zondax::idl_args {
 
+// declare move constructor
+IdlArgs::IdlArgs(IdlArgs &&o) noexcept {
+    ptr = o.ptr;
+    o.ptr = nullptr;
+} 
+
+// declare move assignment
+IdlArgs& IdlArgs::operator=(IdlArgs &&o) noexcept {
+    // check they are not the same object
+    if (&o == this)
+        return *this;
+
+    // now release our inner identity.
+    if (ptr != nullptr)
+        idl_args_destroy(ptr);
+
+    // now takes ownership of the o.agent 
+    ptr = o.ptr;
+
+    // ensure o.agent is null 
+    o.ptr = nullptr;
+
+    return *this;
+}
+
+
 IdlArgs::IdlArgs(IDLArgs* argsPtr) : ptr(argsPtr) {};
 
 IdlArgs::IdlArgs(const std::vector<zondax::idl_value::IdlValue*>& values) {

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -27,6 +27,32 @@ IdlValue::~IdlValue() {
     }    
 }
 
+// declare move constructor
+IdlValue::IdlValue(IdlValue &&o) noexcept: ptr(o.ptr)  {
+    o.ptr = nullptr;
+} 
+
+// declare move assignment
+IdlValue& IdlValue::operator=(IdlValue &&o) noexcept {
+    // check they are not the same object
+    if (&o == this)
+        return *this;
+
+    // now release our inner idl_value.
+    if (ptr != nullptr)
+        idl_value_destroy(ptr);
+
+    // now takes ownership of the o.agent 
+    ptr = o.ptr;
+
+    // ensure o.agent is null 
+    o.ptr = nullptr;
+
+    return *this;
+}
+
+
+
 IdlValue::IdlValue(IDLValue *ptr) : ptr(ptr) {};
 
 IdlValue::IdlValue() : ptr(nullptr) {};
@@ -77,15 +103,11 @@ IdlValue::IdlValue(bool value) {
 
 IdlValue::IdlValue(std::string text) {
     // TODO: Use RetError
-    // RetPtr_u8 error;
-
     ptr = idl_value_with_text(text.c_str(), nullptr);
 }
 
 IdlValue::IdlValue(zondax::principal::Principal principal, bool is_principal) {
     // TODO: Use RetError
-    // RetPtr_u8 error;
-
     ptr = is_principal ? idl_value_with_principal(principal.getBytes().data(), principal.getBytes().size(), nullptr) :
                         idl_value_with_service(principal.getBytes().data(), principal.getBytes().size(), nullptr);
 }
@@ -107,7 +129,6 @@ IdlValue IdlValue::FromReserved(void) {
 
 IdlValue IdlValue::FromNumber(std::string number) {
     // TODO: Use RetError
-    // RetPtr_u8 error;
 
     ptr = idl_value_with_number(number.c_str(), nullptr);
     return IdlValue(ptr);

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -20,6 +20,13 @@
 
 namespace zondax::idl_value {
 
+IdlValue::~IdlValue() {
+    if (ptr != nullptr) {
+        idl_value_destroy(ptr); // Call the destroy function
+        ptr = nullptr;
+    }    
+}
+
 IdlValue::IdlValue(IDLValue *ptr) : ptr(ptr) {};
 
 IdlValue::IdlValue() : ptr(nullptr) {};
@@ -334,10 +341,6 @@ zondax::idl_value_utils::Func IdlValue::getFunc() {
 
 IDLValue* IdlValue::getPtr() const{
     return ptr;
-}
-
-IdlValue::~IdlValue() {
-    idl_value_destroy(ptr); // Call the destroy function
 }
 
 }

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -360,6 +360,10 @@ IDLValue* IdlValue::getPtr() const{
     return ptr;
 }
 
+void IdlValue::resetValue() {
+    ptr = nullptr;
+}
+
 }
 
 

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -34,18 +34,14 @@ IdlValue::IdlValue(IdlValue &&o) noexcept: ptr(o.ptr)  {
 
 // declare move assignment
 IdlValue& IdlValue::operator=(IdlValue &&o) noexcept {
-    // check they are not the same object
     if (&o == this)
         return *this;
 
-    // now release our inner idl_value.
     if (ptr != nullptr)
         idl_value_destroy(ptr);
 
-    // now takes ownership of the o.agent 
     ptr = o.ptr;
 
-    // ensure o.agent is null 
     o.ptr = nullptr;
 
     return *this;

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -13,281 +13,330 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-#include <memory>
 #include "idl_value.h"
-// #include "idl_value_utils.h"
 
+#include <memory>
 
-namespace zondax::idl_value {
+namespace zondax {
 
 IdlValue::~IdlValue() {
-    if (ptr != nullptr) {
-        idl_value_destroy(ptr); // Call the destroy function
-        ptr = nullptr;
-    }    
+  if (ptr != nullptr) {
+    idl_value_destroy(ptr);  // Call the destroy function
+    ptr = nullptr;
+  }
 }
 
 // declare move constructor
-IdlValue::IdlValue(IdlValue &&o) noexcept: ptr(o.ptr)  {
-    o.ptr = nullptr;
-} 
+IdlValue::IdlValue(IdlValue &&o) noexcept : ptr(o.ptr) { o.ptr = nullptr; }
 
 // declare move assignment
-IdlValue& IdlValue::operator=(IdlValue &&o) noexcept {
-    if (&o == this)
-        return *this;
+IdlValue &IdlValue::operator=(IdlValue &&o) noexcept {
+  if (&o == this) return *this;
 
-    if (ptr != nullptr)
-        idl_value_destroy(ptr);
+  if (ptr != nullptr) idl_value_destroy(ptr);
 
-    ptr = o.ptr;
+  ptr = o.ptr;
 
-    o.ptr = nullptr;
+  o.ptr = nullptr;
 
-    return *this;
+  return *this;
 }
 
+IdlValue::IdlValue(IDLValue *ptr) : ptr(ptr){};
 
+IdlValue::IdlValue() : ptr(nullptr){};
 
-IdlValue::IdlValue(IDLValue *ptr) : ptr(ptr) {};
+IdlValue::IdlValue(uint8_t value) { ptr = idl_value_with_nat8(value); }
 
-IdlValue::IdlValue() : ptr(nullptr) {};
+IdlValue::IdlValue(uint16_t value) { ptr = idl_value_with_nat16(value); }
 
-IdlValue::IdlValue(uint8_t value) {
-    ptr = idl_value_with_nat8(value);
-}
+IdlValue::IdlValue(uint32_t value) { ptr = idl_value_with_nat32(value); }
 
-IdlValue::IdlValue(uint16_t value) {
-    ptr = idl_value_with_nat16(value);
-}
+IdlValue::IdlValue(uint64_t value) { ptr = idl_value_with_nat64(value); }
 
-IdlValue::IdlValue(uint32_t value) {
-    ptr = idl_value_with_nat32(value);
-}
+IdlValue::IdlValue(int8_t value) { ptr = idl_value_with_int8(value); }
 
-IdlValue::IdlValue(uint64_t value) {
-    ptr = idl_value_with_nat64(value);
-}
+IdlValue::IdlValue(int16_t value) { ptr = idl_value_with_int16(value); }
 
-IdlValue::IdlValue(int8_t value) {
-    ptr = idl_value_with_int8(value);
-}
+IdlValue::IdlValue(int32_t value) { ptr = idl_value_with_int32(value); }
 
-IdlValue::IdlValue(int16_t value) {
-    ptr = idl_value_with_int16(value);
-}
+IdlValue::IdlValue(int64_t value) { ptr = idl_value_with_int64(value); }
 
-IdlValue::IdlValue(int32_t value) {
-    ptr = idl_value_with_int32(value);
-}
+IdlValue::IdlValue(float value) { ptr = idl_value_with_float32(value); }
 
-IdlValue::IdlValue(int64_t value) {
-    ptr = idl_value_with_int64(value);
-}
+IdlValue::IdlValue(double value) { ptr = idl_value_with_float64(value); }
 
-IdlValue::IdlValue(float value) {
-    ptr = idl_value_with_float32(value);
-}
-
-IdlValue::IdlValue(double value) {
-    ptr = idl_value_with_float64(value);
-}
-
-IdlValue::IdlValue(bool value) {
-    ptr = idl_value_with_bool(value);
-}
+IdlValue::IdlValue(bool value) { ptr = idl_value_with_bool(value); }
 
 IdlValue::IdlValue(std::string text) {
-    // TODO: Use RetError
-    ptr = idl_value_with_text(text.c_str(), nullptr);
+  // TODO: Use RetError
+  ptr = idl_value_with_text(text.c_str(), nullptr);
 }
 
-IdlValue::IdlValue(zondax::principal::Principal principal, bool is_principal) {
-    // TODO: Use RetError
-    ptr = is_principal ? idl_value_with_principal(principal.getBytes().data(), principal.getBytes().size(), nullptr) :
-                        idl_value_with_service(principal.getBytes().data(), principal.getBytes().size(), nullptr);
+IdlValue::IdlValue(zondax::Principal principal, bool is_principal) {
+  // TODO: Use RetError
+  ptr = is_principal
+            ? idl_value_with_principal(principal.getBytes().data(),
+                                       principal.getBytes().size(), nullptr)
+            : idl_value_with_service(principal.getBytes().data(),
+                                     principal.getBytes().size(), nullptr);
 }
 
 IdlValue IdlValue::FromNone(void) {
-    ptr = idl_value_with_none();
-    return IdlValue(ptr);
+  ptr = idl_value_with_none();
+  return IdlValue(ptr);
 }
 
 IdlValue IdlValue::FromNull(void) {
-    ptr = idl_value_with_null();
-    return IdlValue(ptr);
+  ptr = idl_value_with_null();
+  return IdlValue(ptr);
 }
 
 IdlValue IdlValue::FromReserved(void) {
-    ptr = idl_value_with_reserved();
-    return IdlValue(ptr);
+  ptr = idl_value_with_reserved();
+  return IdlValue(ptr);
 }
 
 IdlValue IdlValue::FromNumber(std::string number) {
-    // TODO: Use RetError
+  // TODO: Use RetError
 
-    ptr = idl_value_with_number(number.c_str(), nullptr);
-    return IdlValue(ptr);
+  ptr = idl_value_with_number(number.c_str(), nullptr);
+  return IdlValue(ptr);
 }
 
 IdlValue IdlValue::FromOpt(IdlValue *value) {
-    ptr = idl_value_with_opt(value->ptr);
-    return IdlValue(ptr);
+  ptr = idl_value_with_opt(value->ptr);
+  return IdlValue(ptr);
 }
 
 IdlValue IdlValue::FromVec(const std::vector<const IdlValue *> &elems) {
-    std::vector<const IDLValue *> cElems;
-    cElems.reserve(elems.size());
-    for (const IdlValue *elem : elems) {
-        cElems.push_back(elem->ptr);
-    }
+  std::vector<const IDLValue *> cElems;
+  cElems.reserve(elems.size());
+  for (const IdlValue *elem : elems) {
+    cElems.push_back(elem->ptr);
+  }
 
-    ptr = idl_value_with_vec(cElems.data(), cElems.size());
-    return IdlValue(ptr);
+  ptr = idl_value_with_vec(cElems.data(), cElems.size());
+  return IdlValue(ptr);
 }
 
-IdlValue IdlValue::FromRecord(const std::vector<std::string> &keys, const std::vector<const IdlValue *> &elems) {
-    std::vector<const IDLValue *> cElems;
-    cElems.reserve(elems.size());
-    for (const IdlValue *elem : elems) {
-        cElems.push_back(elem->ptr);
-    }
+IdlValue IdlValue::FromRecord(const std::vector<std::string> &keys,
+                              const std::vector<const IdlValue *> &elems) {
+  std::vector<const IDLValue *> cElems;
+  cElems.reserve(elems.size());
+  for (const IdlValue *elem : elems) {
+    cElems.push_back(elem->ptr);
+  }
 
-    std::vector<const char*> cKeys;
-    cKeys.reserve(keys.size());
-    for (const std::string& key : keys) {
-        cKeys.push_back(key.c_str());
-    }
+  std::vector<const char *> cKeys;
+  cKeys.reserve(keys.size());
+  for (const std::string &key : keys) {
+    cKeys.push_back(key.c_str());
+  }
 
-    ptr = idl_value_with_record(cKeys.data(), cKeys.size(), cElems.data(), cElems.size());
-    return IdlValue(ptr);
+  ptr = idl_value_with_record(cKeys.data(), cKeys.size(), cElems.data(),
+                              cElems.size());
+  return IdlValue(ptr);
 }
 
 IdlValue IdlValue::FromVariant(std::string key, IdlValue *val, uint64_t code) {
-    ptr = idl_value_with_variant(key.c_str(), val->ptr, code);
-    return IdlValue(ptr);
+  ptr = idl_value_with_variant(key.c_str(), val->ptr, code);
+  return IdlValue(ptr);
 }
 
-IdlValue IdlValue::FromFunc(std::vector<uint8_t> vector, std::string func_name) {
-    ptr = idl_value_with_func(vector.data(), vector.size(), func_name.c_str());
-    return IdlValue(ptr);
+IdlValue IdlValue::FromFunc(std::vector<uint8_t> vector,
+                            std::string func_name) {
+  ptr = idl_value_with_func(vector.data(), vector.size(), func_name.c_str());
+  return IdlValue(ptr);
 }
 
 bool IdlValue::getInt8(int8_t *val) {
-    return int8_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return int8_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getInt16(int16_t *val) {
-    return int16_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return int16_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getInt32(int32_t *val) {
-    return int32_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return int32_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getInt64(int64_t *val) {
-    return int64_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return int64_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getNat8(uint8_t *val) {
-    return nat8_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return nat8_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getNat16(uint16_t *val) {
-    return nat16_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return nat16_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getNat32(uint32_t *val) {
-    return nat32_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return nat32_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getNat64(uint64_t *val) {
-    return nat64_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return nat64_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getFloat32(float *val) {
-    return float32_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return float32_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getFloat64(double *val) {
-    return float64_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return float64_from_idl_value(ptr, val);
 }
 
 bool IdlValue::getBool(bool *val) {
-    return bool_from_idl_value(ptr, val);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return false;
+  }
+  return bool_from_idl_value(ptr, val);
 }
 
 std::string IdlValue::getText() {
-    CText *ctext = text_from_idl_value(ptr);
-    const char* str = ctext_str(ctext);
-    uintptr_t len = ctext_len(ctext);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return "";
+  }
+  CText *ctext = text_from_idl_value(ptr);
+  const char *str = ctext_str(ctext);
+  uintptr_t len = ctext_len(ctext);
 
-    std::string text(str, len);
+  std::string text(str, len);
 
-    ctext_destroy(ctext);
+  ctext_destroy(ctext);
 
-    return text;
+  return text;
 }
 
-zondax::principal::Principal IdlValue::getPrincipal() {
-    CPrincipal *p = principal_from_idl_value(ptr);
+std::optional<zondax::Principal> IdlValue::getPrincipal() {
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return std::nullopt;
+  }
+  CPrincipal *p = principal_from_idl_value(ptr);
 
-    std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
-    zondax::principal::Principal principal(bytes);
+  std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
+  zondax::Principal principal(bytes);
 
-    principal_destroy(p);
+  principal_destroy(p);
 
-    return principal;
+  return std::make_optional(std::move(principal));
 }
 
-zondax::principal::Principal IdlValue::getService() {
-    CPrincipal *p = service_from_idl_value(ptr);
+std::optional<zondax::Principal> IdlValue::getService() {
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return std::nullopt;
+  }
+  CPrincipal *p = service_from_idl_value(ptr);
 
-    std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
-    zondax::principal::Principal principal(bytes);
+  std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
+  zondax::Principal principal(bytes);
 
-    principal_destroy(p);
+  principal_destroy(p);
 
-    return principal;
+  return std::make_optional(std::move(principal));
 }
 
 std::string IdlValue::getNumber() {
-    CText *ctext = text_from_idl_value(ptr);
-        const char* str = ctext_str(ctext);
-    uintptr_t len = ctext_len(ctext);
+  if (ptr == nullptr) {
+    std::cerr << "IdlValue instance uninitialized" << std::endl;
+    return "";
+  }
+  CText *ctext = text_from_idl_value(ptr);
+  const char *str = ctext_str(ctext);
+  uintptr_t len = ctext_len(ctext);
 
-    std::string text(str, len);
+  std::string text(str, len);
 
-    ctext_destroy(ctext);
+  ctext_destroy(ctext);
 
-    return text;
+  return text;
 }
 
-IdlValue IdlValue::getOpt() {
-    IDLValue* result = opt_from_idl_value(ptr);
-    return IdlValue(result);
+std::optional<IdlValue> IdlValue::getOpt() {
+  if (ptr == nullptr) {
+    return std::nullopt;
+  }
+
+  IDLValue *result = opt_from_idl_value(ptr);
+
+  if (result == nullptr) {
+    return std::nullopt;
+  }
+
+  return IdlValue(result);
 }
 
 std::vector<IdlValue> IdlValue::getVec() {
-    struct CIDLValuesVec* cVec = vec_from_idl_value(ptr);
-    uintptr_t length = cidlval_vec_len(cVec);
+  if (ptr == nullptr) {
+    return std::vector<IdlValue>();
+  }
+  struct CIDLValuesVec *cVec = vec_from_idl_value(ptr);
+  uintptr_t length = cidlval_vec_len(cVec);
 
-    std::vector<IdlValue> result;
-    result.reserve(length);
+  std::vector<IdlValue> result;
+  result.reserve(length);
 
-    for (uintptr_t i = 0; i < length; ++i) {
-        const IDLValue* valuePtr = cidlval_vec_value(cVec, i);
-        result.emplace_back(valuePtr);
-    }
+  for (uintptr_t i = 0; i < length; ++i) {
+    const IDLValue *valuePtr = cidlval_vec_value(cVec, i);
+    result.emplace_back(valuePtr);
+  }
 
-    // Free the allocated CIDLValuesVec
-    cidlval_vec_destroy(cVec);
+  // Free the allocated CIDLValuesVec
+  cidlval_vec_destroy(cVec);
 
-    return result;
+  return result;
 }
 
 // TODO: Enable later forward declaration is tricky here,
-// specially because it requires raw pointers, which might lead 
+// specially because it requires raw pointers, which might lead
 // to aliasing of the inner idlValue ptr, and this if doing wrong
 // could cause memory issues, double free and so on.
 // also smart pointers do not work here as types are not fully
@@ -300,7 +349,8 @@ std::vector<IdlValue> IdlValue::getVec() {
 //     // Extract keys
 //     uintptr_t keysLength = crecord_keys_len(cRecord);
 //     for (uintptr_t i = 0; i < keysLength; ++i) {
-//         const char* keyPtr = reinterpret_cast<const char*>(crecord_get_key(cRecord, i));
+//         const char* keyPtr = reinterpret_cast<const
+//         char*>(crecord_get_key(cRecord, i));
 //         result.keys.emplace_back(keyPtr);
 //     }
 //
@@ -322,7 +372,8 @@ std::vector<IdlValue> IdlValue::getVec() {
 //     zondax::idl_value_utils::Variant result;
 //
 //     // Extract ID
-//     result.id.assign(cvariant_id(cVariant), cvariant_id(cVariant) + cvariant_id_len(cVariant));
+//     result.id.assign(cvariant_id(cVariant), cvariant_id(cVariant) +
+//     cvariant_id_len(cVariant));
 //
 //     // Extract value
 //     const IDLValue* valPtr = cvariant_idlvalue(cVariant);
@@ -338,32 +389,31 @@ std::vector<IdlValue> IdlValue::getVec() {
 //     return result;
 // }
 
-zondax::idl_value_utils::Func IdlValue::getFunc() {
-    struct CFunc* cFunc = func_from_idl_value(ptr);
-    zondax::idl_value_utils::Func result;
+std::optional<zondax::Func> IdlValue::getFunc() {
+  if (ptr == nullptr) {
+    return std::nullopt;
+  }
+  struct CFunc *cFunc = func_from_idl_value(ptr);
+  zondax::Func result;
 
-    // Extract string
-    result.s = std::string(cfunc_string(cFunc), cfunc_string(cFunc) + cfunc_string_len(cFunc));
+  // Extract string
+  result.s = std::string(cfunc_string(cFunc),
+                         cfunc_string(cFunc) + cfunc_string_len(cFunc));
 
-    // Extract principal
-    struct CPrincipal* cPrincipal = cfunc_principal(cFunc);
-    std::vector<uint8_t> vec = std::vector<uint8_t>(cPrincipal->ptr, cPrincipal->ptr + cPrincipal->len);
-    result.p = zondax::principal::Principal(vec);
+  // Extract principal
+  struct CPrincipal *cPrincipal = cfunc_principal(cFunc);
+  std::vector<uint8_t> vec =
+      std::vector<uint8_t>(cPrincipal->ptr, cPrincipal->ptr + cPrincipal->len);
+  result.p = zondax::Principal(vec);
 
-    // Free the allocated CFunc
-    cfunc_destroy(cFunc);
+  // Free the allocated CFunc
+  cfunc_destroy(cFunc);
 
-    return result;
+  return std::optional<zondax::Func>(std::move(result));
 }
 
-IDLValue* IdlValue::getPtr() const{
-    return ptr;
-}
+IDLValue *IdlValue::getPtr() const { return ptr; }
 
-void IdlValue::resetValue() {
-    ptr = nullptr;
-}
+void IdlValue::resetValue() { ptr = nullptr; }
 
-}
-
-
+}  // namespace zondax

--- a/lib-agent-cpp/src/principal.cpp
+++ b/lib-agent-cpp/src/principal.cpp
@@ -13,171 +13,173 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-#include <optional>
-#include <cstdlib>
-
 #include "principal.h"
 
-namespace zondax::principal {
+#include <cstdlib>
+#include <optional>
 
-void error_callback(const unsigned char *data, int len, void *user_data) {
-    std::string error_msg((const char *)data, len);
-    *(std::string *)user_data = error_msg;
+namespace zondax {
+
+void Principal::error_callback(const unsigned char *data, int len,
+                               void *user_data) {
+  std::string error_msg((const char *)data, len);
+  *(std::string *)user_data = error_msg;
 }
 
 // declare move constructor
 Principal::Principal(Principal &&o) noexcept : bytes(std::move(o.bytes)) {
-    cPrincipal = o.cPrincipal;
-    o.cPrincipal = nullptr;
-} 
+  cPrincipal = o.cPrincipal;
+  o.cPrincipal = nullptr;
+}
 
 // declare move assignment
-Principal& Principal::operator=(Principal &&o) noexcept {
-    // check they are not the same object
-    if (&o == this)
-        return *this;
+Principal &Principal::operator=(Principal &&o) noexcept {
+  // check they are not the same object
+  if (&o == this) return *this;
 
-    if (cPrincipal != nullptr)
-        principal_destroy(cPrincipal);
+  if (cPrincipal != nullptr) principal_destroy(cPrincipal);
 
-    cPrincipal = o.cPrincipal;
-    bytes = std::move(o.bytes);
+  cPrincipal = o.cPrincipal;
+  bytes = std::move(o.bytes);
 
-    o.cPrincipal = nullptr;
+  o.cPrincipal = nullptr;
 
-    return *this;
+  return *this;
 }
 
 /**
  * @brief Constructs a Principal object from a vector of bytes.
  * @param data The vector of bytes to initialize the Principal.
  *
- * This constructor initializes a Principal object with the provided vector of bytes.
- * The bytes parameter contains the data used to construct the Principal.
+ * This constructor initializes a Principal object with the provided vector of
+ * bytes. The bytes parameter contains the data used to construct the Principal.
  */
-Principal::Principal(const std::vector<unsigned char>& data) : bytes(data) {
-    cPrincipal = principal_from_slice(data.data(), data.size());
+Principal::Principal(const std::vector<unsigned char> &data) : bytes(data) {
+  cPrincipal = principal_from_slice(data.data(), data.size());
 
-    std::vector<unsigned char> outBytes(cPrincipal->ptr, cPrincipal->ptr + cPrincipal->len);
-    bytes = outBytes;
+  std::vector<unsigned char> outBytes(cPrincipal->ptr,
+                                      cPrincipal->ptr + cPrincipal->len);
+  bytes = outBytes;
 }
 
 Principal::Principal(bool anonym) {
-    cPrincipal = anonym ? principal_anonymous() : principal_management_canister(); 
+  cPrincipal = anonym ? principal_anonymous() : principal_management_canister();
 
-    std::vector<unsigned char> outBytes(cPrincipal->ptr, cPrincipal->ptr + cPrincipal->len);
-    bytes =  outBytes;
+  std::vector<unsigned char> outBytes(cPrincipal->ptr,
+                                      cPrincipal->ptr + cPrincipal->len);
+  bytes = outBytes;
 }
 
-Principal Principal::SelfAuthenticating(const std::vector<uint8_t> &public_key) {
-    CPrincipal* p = principal_self_authenticating(public_key.data(), public_key.size());
+Principal Principal::SelfAuthenticating(
+    const std::vector<uint8_t> &public_key) {
+  CPrincipal *p =
+      principal_self_authenticating(public_key.data(), public_key.size());
 
-    std::vector<unsigned char> outBytes(p->ptr, p->ptr + p->len);
-    principal_destroy(p);
-    return Principal(outBytes);
-}
-
-/**
- * @brief 
- * 
- * @param bytes 
- * @param errorCallback 
- * @return std::optional<Principal> 
- */
-std::variant<Principal, std::string> Principal::TryFromSlice(const std::vector<uint8_t> &bytes) {
-
-    std::string data;
-
-    RetError ret;
-    ret.user_data = (void *)&data;
-    ret.call = error_callback;
-
-    // get error from error_ret here and send it on string of result
-    CPrincipal *p = principal_try_from_slice(bytes.data(), bytes.size(), &ret);
-
-    if (p == nullptr) {
-        std::variant<Principal, std::string> error(data);
-        return error;
-    }
-
-    // there is not constructor variant that supports reading from pointers
-    // use tradicional loob to push_back bytes
-    std::vector<unsigned char> outBytes;
-    for(int i=0; i<p->len; ++i) {
-        outBytes.push_back(*(p->ptr + i));
-    }
-
-    std::variant<Principal, std::string> ok{std::in_place_type<Principal>, outBytes};
-
-    return ok;
+  std::vector<unsigned char> outBytes(p->ptr, p->ptr + p->len);
+  principal_destroy(p);
+  return Principal(outBytes);
 }
 
 /**
- * @brief 
- * 
- * @param text 
- * @param errorCallback 
- * @return std::optional<Principal> 
+ * @brief
+ *
+ * @param bytes
+ * @param errorCallback
+ * @return std::optional<Principal>
  */
-std::variant<Principal, std::string> Principal::FromText(const std::string& text) {
+std::variant<Principal, std::string> Principal::TryFromSlice(
+    const std::vector<uint8_t> &bytes) {
+  std::string data;
 
-    std::string data;
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = Principal::error_callback;
 
-    RetError ret;
-    ret.user_data = (void *)&data;
-    ret.call = error_callback;
+  // get error from error_ret here and send it on string of result
+  CPrincipal *p = principal_try_from_slice(bytes.data(), bytes.size(), &ret);
 
-    // get error from error_ret here and send it on string of result
-    CPrincipal *p = principal_from_text(text.c_str(), &ret);
+  if (p == nullptr) {
+    std::variant<Principal, std::string> error(data);
+    return error;
+  }
 
-    if (p == nullptr) {
-        std::variant<Principal, std::string> error(data);
-        return error;
-    }
+  // there is not constructor variant that supports reading from pointers
+  // use tradicional loob to push_back bytes
+  std::vector<unsigned char> outBytes;
+  for (int i = 0; i < p->len; ++i) {
+    outBytes.push_back(*(p->ptr + i));
+  }
 
-    // there is not constructor variant that supports reading from pointers
-    // use tradicional loob to push_back bytes
-    std::vector<unsigned char> outBytes;
-    for(int i=0; i<p->len; ++i) {
-        outBytes.push_back(*(p->ptr + i));
-    }
+  std::variant<Principal, std::string> ok{std::in_place_type<Principal>,
+                                          outBytes};
 
-    std::variant<Principal, std::string> ok{std::in_place_type<Principal>, outBytes};
-
-    return ok;
-
+  return ok;
 }
 
 /**
- * @brief 
- * 
- * @param data 
- * @param errorCallback 
- * @return std::string 
+ * @brief
+ *
+ * @param text
+ * @param errorCallback
+ * @return std::optional<Principal>
  */
-std::string Principal::ToText(const std::vector<unsigned char>& data) {
-    // get error from error_ret here and send it on string of result
-    CPrincipal *p = principal_to_text(data.data(), data.size(), nullptr);
+std::variant<Principal, std::string> Principal::FromText(
+    const std::string &text) {
+  std::string data;
 
-    if (p == nullptr) {
-        return "";
-    }
+  RetError ret;
+  ret.user_data = (void *)&data;
+  ret.call = Principal::error_callback;
 
-    std::string result(reinterpret_cast<const char*>(p->ptr), p->len);
+  // get error from error_ret here and send it on string of result
+  CPrincipal *p = principal_from_text(text.c_str(), &ret);
 
-    principal_destroy(p);
+  if (p == nullptr) {
+    std::variant<Principal, std::string> error(data);
+    return error;
+  }
 
-    return result;
+  // there is not constructor variant that supports reading from pointers
+  // use tradicional loob to push_back bytes
+  std::vector<unsigned char> outBytes;
+  for (int i = 0; i < p->len; ++i) {
+    outBytes.push_back(*(p->ptr + i));
+  }
+
+  std::variant<Principal, std::string> ok{std::in_place_type<Principal>,
+                                          outBytes};
+
+  return ok;
 }
 
-std::vector<unsigned char> Principal::getBytes() const {
-    return bytes;
+/**
+ * @brief
+ *
+ * @param data
+ * @param errorCallback
+ * @return std::string
+ */
+std::string Principal::ToText(const std::vector<unsigned char> &data) {
+  // get error from error_ret here and send it on string of result
+  CPrincipal *p = principal_to_text(data.data(), data.size(), nullptr);
+
+  if (p == nullptr) {
+    return "";
+  }
+
+  std::string result(reinterpret_cast<const char *>(p->ptr), p->len);
+
+  principal_destroy(p);
+
+  return result;
 }
+
+std::vector<unsigned char> Principal::getBytes() const { return bytes; }
 
 Principal::~Principal() {
-    if (cPrincipal != nullptr) {
-        principal_destroy(cPrincipal);
-    }
+  if (cPrincipal != nullptr) {
+    principal_destroy(cPrincipal);
+  }
 }
 
-}
+}  // namespace zondax

--- a/lib-agent-cpp/src/principal.cpp
+++ b/lib-agent-cpp/src/principal.cpp
@@ -47,13 +47,6 @@ Principal &Principal::operator=(Principal &&o) noexcept {
   return *this;
 }
 
-/**
- * @brief Constructs a Principal object from a vector of bytes.
- * @param data The vector of bytes to initialize the Principal.
- *
- * This constructor initializes a Principal object with the provided vector of
- * bytes. The bytes parameter contains the data used to construct the Principal.
- */
 Principal::Principal(const std::vector<unsigned char> &data) : bytes(data) {
   cPrincipal = principal_from_slice(data.data(), data.size());
 
@@ -80,13 +73,6 @@ Principal Principal::SelfAuthenticating(
   return Principal(outBytes);
 }
 
-/**
- * @brief
- *
- * @param bytes
- * @param errorCallback
- * @return std::optional<Principal>
- */
 std::variant<Principal, std::string> Principal::TryFromSlice(
     const std::vector<uint8_t> &bytes) {
   std::string data;
@@ -116,13 +102,6 @@ std::variant<Principal, std::string> Principal::TryFromSlice(
   return ok;
 }
 
-/**
- * @brief
- *
- * @param text
- * @param errorCallback
- * @return std::optional<Principal>
- */
 std::variant<Principal, std::string> Principal::FromText(
     const std::string &text) {
   std::string data;
@@ -152,13 +131,6 @@ std::variant<Principal, std::string> Principal::FromText(
   return ok;
 }
 
-/**
- * @brief
- *
- * @param data
- * @param errorCallback
- * @return std::string
- */
 std::string Principal::ToText(const std::vector<unsigned char> &data) {
   // get error from error_ret here and send it on string of result
   CPrincipal *p = principal_to_text(data.data(), data.size(), nullptr);

--- a/lib-agent-cpp/src/principal.cpp
+++ b/lib-agent-cpp/src/principal.cpp
@@ -25,6 +25,31 @@ void error_callback(const unsigned char *data, int len, void *user_data) {
     *(std::string *)user_data = error_msg;
 }
 
+// declare move constructor
+Principal::Principal(Principal &&o) noexcept : bytes(std::move(o.bytes)) {
+    cPrincipal = o.cPrincipal;
+} 
+
+// declare move assignment
+Principal& Principal::operator=(Principal &&o) noexcept {
+    // check they are not the same object
+    if (&o == this)
+        return *this;
+
+    // now release our inner identity.
+    if (cPrincipal != nullptr)
+        principal_destroy(cPrincipal);
+
+    // now takes ownership of the values
+    cPrincipal = o.cPrincipal;
+    bytes = std::move(o.bytes);
+
+    // set other to null
+    o.cPrincipal = nullptr;
+
+    return *this;
+}
+
 /**
  * @brief Constructs a Principal object from a vector of bytes.
  * @param data The vector of bytes to initialize the Principal.
@@ -133,8 +158,6 @@ std::string Principal::ToText(const std::vector<unsigned char>& data) {
     CPrincipal *p = principal_to_text(data.data(), data.size(), nullptr);
 
     if (p == nullptr) {
-        // TODO: destroy call over a null ptr?
-        // principal_destroy(p);
         return "";
     }
 


### PR DESCRIPTION
This:
- enable move semantics in all classes to avoid double free errors, as inner pointer must have one owner at any time.
- Enhance file API to be more idiomatic.
- fix ic test issues, it is working now.

fixes #12 #9 and possible #10 

<!-- ClickUpRef: 861mzankf -->
:link: [zboto Link](https://app.clickup.com/t/861mzankf)