### PR TITLE
Add template get function

### DIFF
--- a/ic-agent-wrapper/bindings.h
+++ b/ic-agent-wrapper/bindings.h
@@ -159,6 +159,17 @@ const IDLValue *cidlval_vec(const struct CIDLValuesVec *ptr);
 const IDLValue *cidlval_vec_value(const struct CIDLValuesVec *ptr, uintptr_t index);
 
 /**
+ * @brief Get pointer to IDLValue at specific index
+ *
+ * @param ptr CIDLValuesVec structure pointer
+ * @param index to specific index
+ * @return Pointer to IDLValue
+ * @note This gives ownership of the requested value to the caller, who is in charge
+ * of free the memory.
+ */
+const IDLValue *cidlval_vec_value_take(struct CIDLValuesVec *ptr, uintptr_t index);
+
+/**
  * @brief Get CIDLValuesVec length
  *
  * @param ptr CIDLValuesVec structure pointer

--- a/lib-agent-c/inc/zondax_ic.h
+++ b/lib-agent-c/inc/zondax_ic.h
@@ -159,6 +159,17 @@ const IDLValue *cidlval_vec(const struct CIDLValuesVec *ptr);
 const IDLValue *cidlval_vec_value(const struct CIDLValuesVec *ptr, uintptr_t index);
 
 /**
+ * @brief Get pointer to IDLValue at specific index
+ *
+ * @param ptr CIDLValuesVec structure pointer
+ * @param index to specific index
+ * @return Pointer to IDLValue
+ * @note This gives ownership of the requested value to the caller, who is in charge
+ * of free the memory.
+ */
+const IDLValue *cidlval_vec_value_take(struct CIDLValuesVec *ptr, uintptr_t index);
+
+/**
  * @brief Get CIDLValuesVec length
  *
  * @param ptr CIDLValuesVec structure pointer

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -24,6 +24,7 @@
 
 #include "idl_value_utils.h"
 #include "principal.h"
+#include "service.h"
 
 extern "C" {
 #include "zondax_ic.h"

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -31,6 +31,10 @@ extern "C" {
 
 namespace zondax {
 
+struct Number {
+  std::string value;
+};
+
 class IdlValue {
   friend class IdlArgs;
 
@@ -82,26 +86,14 @@ class IdlValue {
   IdlValue FromFunc(std::vector<uint8_t> vector, std::string func_name);
 
   // Get types
-  bool getInt8(int8_t *val);
-  bool getInt16(int16_t *val);
-  bool getInt32(int32_t *val);
-  bool getInt64(int64_t *val);
-  bool getNat8(uint8_t *val);
-  bool getNat16(uint16_t *val);
-  bool getNat32(uint32_t *val);
-  bool getNat64(uint64_t *val);
-  bool getFloat32(float *val);
-  bool getFloat64(double *val);
-  bool getBool(bool *val);
-  std::string getText();
-  std::optional<zondax::Principal> getPrincipal();
+  template <typename T>
+  std::optional<T> get();
+
   std::optional<zondax::Principal> getService();
-  std::string getNumber();
   std::optional<IdlValue> getOpt();
   std::vector<IdlValue> getVec();
   // zondax::idl_value_utils::Record getRecord();
   // zondax::idl_value_utils::Variant getVariant();
-  std::optional<zondax::Func> getFunc();
 
   // methods bellow must be use carefully
   // the first will aliase pointer, breaking move semantics only

--- a/lib-agent-cpp/inc/service.h
+++ b/lib-agent-cpp/inc/service.h
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#ifndef SERVICE_H
+#define SERVICE_H
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <variant>
+#include <vector>
+
+#include "principal.h"
+
+extern "C" {
+#include "zondax_ic.h"
+}
+
+namespace zondax {
+class Service {
+ private:
+  zondax::Principal princ;
+
+ public:
+  // Disable copies, just move semantics
+  Service(const Service &args) = delete;
+  void operator=(const Service &) = delete;
+
+  /**
+   * @brief Move constructor for Principal objects.
+   *
+   * @param o The Principal object to move.
+   *
+   * This constructor moves the content of the provided Principal object into a
+   * new Principal object.
+   */
+  Service(Service &&o) noexcept;
+
+  /**
+   * @brief Move assignment operator for Principal objects.
+   *
+   * @param o The Principal object to move.
+   *
+   * This operator moves the content of the provided Principal object into an
+   * existing Principal object.
+   */
+  Service &operator=(Service &&o) noexcept;
+
+  /**
+   * @brief Constructs a service by taking ownership of the passed principal
+   * obj.
+   *
+   * @param o The Principal object to move.
+   *
+   * This operator moves the content of the provided Principal object into an
+   * existing Principal object.
+   */
+  explicit Service(zondax::Principal &&principal) noexcept;
+
+  /**
+   * @brief Borrow the inner principal object.
+   *
+   * @return Reference to the Principal instance.
+   */
+  const zondax::Principal &principal() const;
+
+  /**
+   * @brief Take out the principal obj.
+   *
+   * @return The Principal instance.
+   */
+  zondax::Principal principal_take() noexcept;
+
+  ~Service();
+};
+}  // namespace zondax
+#endif  // SERVICE_H

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -179,6 +179,8 @@ std::optional<std::string> IdlValue::get() {
     return std::nullopt;
   }
   CText *ctext = text_from_idl_value(ptr);
+  if (ctext == nullptr) return std::nullopt;
+
   const char *str = ctext_str(ctext);
   uintptr_t len = ctext_len(ctext);
 
@@ -191,10 +193,10 @@ std::optional<std::string> IdlValue::get() {
 
 template <>
 std::optional<zondax::Principal> IdlValue::get() {
-  if (ptr == nullptr) {
-    return std::nullopt;
-  }
+  if (ptr == nullptr) return std::nullopt;
+
   CPrincipal *p = principal_from_idl_value(ptr);
+  if (p == nullptr) return std::nullopt;
 
   std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
   zondax::Principal principal(bytes);
@@ -210,6 +212,8 @@ std::optional<Number> IdlValue::get() {
     return std::nullopt;
   }
   CText *ctext = number_from_idl_value(ptr);
+  if (ctext == nullptr) return std::nullopt;
+
   const char *str = ctext_str(ctext);
   uintptr_t len = ctext_len(ctext);
 
@@ -228,6 +232,8 @@ std::optional<zondax::Func> IdlValue::get() {
     return std::nullopt;
   }
   struct CFunc *cFunc = func_from_idl_value(ptr);
+  if (cFunc == nullptr) return std::nullopt;
+
   zondax::Func result;
 
   // Extract string
@@ -255,6 +261,8 @@ std::optional<std::vector<IdlValue> > IdlValue::get() {
   // call bellow creates a new IDLValue::Vec,
   // this means it "clones" from this.ptr
   struct CIDLValuesVec *cVec = vec_from_idl_value(ptr);
+  if (cVec == nullptr) return std::nullopt;
+
   uintptr_t length = cidlval_vec_len(cVec);
 
   std::vector<IdlValue> result;

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -275,19 +275,24 @@ std::optional<std::vector<IdlValue> > IdlValue::get() {
   return std::make_optional(std::move(result));
 }
 
-std::optional<zondax::Principal> IdlValue::getService() {
+template <>
+std::optional<zondax::Service> IdlValue::get() {
   if (ptr == nullptr) {
-    std::cerr << "IdlValue instance uninitialized" << std::endl;
     return std::nullopt;
   }
+
   CPrincipal *p = service_from_idl_value(ptr);
+
+  if (p == nullptr) return std::nullopt;
 
   std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
   zondax::Principal principal(bytes);
 
+  // there is not issue in destroying raw principal
+  // because bytes makes a deep copy
   principal_destroy(p);
 
-  return std::make_optional(std::move(principal));
+  return std::make_optional(zondax::Service(std::move(principal)));
 }
 
 std::optional<IdlValue> IdlValue::getOpt() {

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -209,7 +209,7 @@ std::optional<Number> IdlValue::get() {
   if (ptr == nullptr) {
     return std::nullopt;
   }
-  CText *ctext = text_from_idl_value(ptr);
+  CText *ctext = number_from_idl_value(ptr);
   const char *str = ctext_str(ctext);
   uintptr_t len = ctext_len(ctext);
 

--- a/lib-agent-cpp/src/service.cpp
+++ b/lib-agent-cpp/src/service.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#include "service.h"
+
+#include <cstdlib>
+#include <optional>
+
+namespace zondax {
+
+// declare move constructor
+Service::Service(Service &&o) noexcept : princ(std::move(o.princ)) {}
+
+// declare move assignment
+Service &Service::operator=(Service &&o) noexcept {
+  // check they are not the same object
+  if (&o == this) return *this;
+
+  princ = std::move(o.princ);
+
+  return *this;
+}
+
+Service::Service(zondax::Principal &&p) noexcept : princ(std::move(p)) {}
+
+Service::~Service() {}
+
+// zondax::Principal &Service::principal() noexcept { return principal; }
+const zondax::Principal &Service::principal() const { return princ; }
+
+zondax::Principal Service::principal_take() noexcept {
+  return std::move(princ);
+}
+
+}  // namespace zondax


### PR DESCRIPTION
This define a generic get function to retrieve values from the inner IdlValue class, this implementation supports:
- all primitives types integer, bool, float and nats.
- string
- IDLValue::Number
- Principal
- Func
- Vec<IdlValue>
- Service

not supported yet: 
- Record, see #19 
- Variant, see #11
- Opt

fixes #21 #22 #23

<!-- ClickUpRef: 861n01h7n -->
:link: [zboto Link](https://app.clickup.com/t/861n01h7n)