### PR TITLE
Templated constructors for IdlValue

### DIFF
--- a/ic-agent-wrapper/Cargo.toml
+++ b/ic-agent-wrapper/Cargo.toml
@@ -38,6 +38,7 @@ cty = "0.2.2"
 safer-ffi = { version = "0.0.10", features = ["proc_macros"] }
 crypto_api_osrandom = "0.2.0"
 const-str = "0.5.2"
+arrayref = "0.3.7"
 
 [build-dependencies]
 cbindgen = "0.20.0"

--- a/ic-agent-wrapper/bindings.h
+++ b/ic-agent-wrapper/bindings.h
@@ -828,7 +828,7 @@ struct CText *number_from_idl_value(const IDLValue *ptr);
 /**
  * @brief Create Opt IDLValue
  *
- * @param number Pointer to IDLValue
+ * @param number Pointer to IDLValue (ownership is taken)
  * @return Pointer to the Opt IDLValue Structure
  */
 IDLValue *idl_value_with_opt(IDLValue *value);
@@ -873,15 +873,23 @@ struct CIDLValuesVec *vec_from_idl_value(const IDLValue *ptr);
  * @param keys Pointer to array of keys
  * @param keys_len Number of Keys
  * @param vals Pointer to array of IDLValues
- * @param vals_len Number of Values, take in account rust will take
+ * @param vals_len Number of Values
+ * @param keys_are_ids If set to true, keys are expected to be [u8; 4] and will
+ * be read as LE u32 and the resulting record will have unnamed/id labels based
+ * on the value of the keys
+ *
+ * Take in account rust will take
  * ownership of the memory where this array is stored and free it once it comes out of
- * the function scope. So the user should not use this array after calling
+ * the function scope.
+ * So the user should not use this array after calling this function
+ *
  * @return Pointer to IDLValue Structure
  */
 IDLValue *idl_value_with_record(const char *const *keys,
                                 int keys_len,
                                 const IDLValue *const *vals,
-                                int vals_len);
+                                int vals_len,
+                                bool keys_are_ids);
 
 /**
  * @brief Get Record from IDLValue

--- a/ic-agent-wrapper/src/candid/mod.rs
+++ b/ic-agent-wrapper/src/candid/mod.rs
@@ -45,13 +45,13 @@ pub extern "C" fn empty_idl_args() -> Box<IDLArgs> {
     Box::new(args)
 }
 
-/// @brief Push a new IDLValue into values list 
-/// @param args The IDLArgs instance where `value` would be added. 
-/// @param value that is going to be pushed into 
+/// @brief Push a new IDLValue into values list
+/// @param args The IDLArgs instance where `value` would be added.
+/// @param value that is going to be pushed into
 /// the list.
 /// @note: This takes ownership of the passed value
 #[no_mangle]
-pub extern "C" fn idl_args_push_value(args: &mut IDLArgs, value: Box<IDLValue> ) {
+pub extern "C" fn idl_args_push_value(args: &mut IDLArgs, value: Box<IDLValue>) {
     args.args.push(*value);
 }
 
@@ -93,7 +93,11 @@ pub extern "C" fn idl_args_from_text(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -109,7 +113,7 @@ pub extern "C" fn idl_args_from_text(
 #[no_mangle]
 pub extern "C" fn idl_args_to_bytes(
     idl_args: &IDLArgs,
-    error_ret: Option<&mut RetError >,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<CBytes>> {
     let idl_bytes = idl_args.to_bytes();
 
@@ -122,7 +126,11 @@ pub extern "C" fn idl_args_to_bytes(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -141,7 +149,7 @@ pub extern "C" fn idl_args_to_bytes(
 pub extern "C" fn idl_args_from_bytes(
     bytes: *const u8,
     bytes_len: c_int,
-    error_ret: Option<&mut RetError >,
+    error_ret: Option<&mut RetError>,
 ) -> Option<Box<IDLArgs>> {
     let slice = unsafe { std::slice::from_raw_parts(bytes, bytes_len as usize) };
 
@@ -156,7 +164,11 @@ pub extern "C" fn idl_args_from_bytes(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -251,7 +263,11 @@ pub extern "C" fn idl_value_format_text(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -293,7 +309,11 @@ pub extern "C" fn idl_value_with_nat(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -662,7 +682,11 @@ pub extern "C" fn idl_value_with_text(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -714,7 +738,11 @@ pub extern "C" fn idl_value_with_principal(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -769,7 +797,11 @@ pub extern "C" fn idl_value_with_service(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
             None
         }
@@ -791,7 +823,6 @@ pub extern "C" fn service_from_idl_value(ptr: &IDLValue) -> Option<Box<CPrincipa
 
     let ptr = Box::into_raw(arr.into_boxed_slice()) as *mut u8;
     Some(Box::new(CPrincipal { ptr, len }))
-
 }
 
 /// @brief Create IDLValue with Service
@@ -819,7 +850,11 @@ pub extern "C" fn idl_value_with_number(
                 CString::new(fallback_error).expect("Fallback error message is invalid")
             });
             if let Some(error_ret) = error_ret {
-                (error_ret.call)(c_string.as_ptr() as _, c_string.as_bytes().len() as _, error_ret.user_data);
+                (error_ret.call)(
+                    c_string.as_ptr() as _,
+                    c_string.as_bytes().len() as _,
+                    error_ret.user_data,
+                );
             }
 
             None
@@ -1202,7 +1237,6 @@ mod tests {
 
     #[test]
     fn idl_args_from_text_test() {
-
         let result = idl_args_from_text(IDL_ARGS_TEXT_C.as_ptr() as *const c_char, None);
         let result = result.unwrap();
         assert_eq!(IDLArgs::new(&IDL_VALUES), *result);
@@ -1217,24 +1251,16 @@ mod tests {
 
     #[test]
     fn idl_args_from_bytes_test() {
-
-        let result = idl_args_from_bytes(
-            IDL_ARGS_BYTES.as_ptr(),
-            IDL_ARGS_BYTES.len() as c_int,
-            None,
-        );
+        let result =
+            idl_args_from_bytes(IDL_ARGS_BYTES.as_ptr(), IDL_ARGS_BYTES.len() as c_int, None);
         let result = result.unwrap();
         assert_eq!(IDLArgs::new(&IDL_VALUES), *result);
     }
 
     #[test]
     fn idl_args_from_vec_test() {
-
-        let result = idl_args_from_bytes(
-            IDL_ARGS_BYTES.as_ptr(),
-            IDL_ARGS_BYTES.len() as c_int,
-            None,
-        );
+        let result =
+            idl_args_from_bytes(IDL_ARGS_BYTES.as_ptr(), IDL_ARGS_BYTES.len() as c_int, None);
         let result = result.unwrap();
         assert_eq!(IDLArgs::new(&IDL_VALUES), *result);
     }
@@ -1443,9 +1469,7 @@ mod tests {
             Box::into_raw(value_bool.clone()),
             Box::into_raw(value_null.clone()),
             Box::into_raw(value_principal.clone()),
-
         ];
-
 
         let expected = IDLValue::Record(vec![
             IDLField {

--- a/lib-agent-c/inc/zondax_ic.h
+++ b/lib-agent-c/inc/zondax_ic.h
@@ -828,7 +828,7 @@ struct CText *number_from_idl_value(const IDLValue *ptr);
 /**
  * @brief Create Opt IDLValue
  *
- * @param number Pointer to IDLValue
+ * @param number Pointer to IDLValue (ownership is taken)
  * @return Pointer to the Opt IDLValue Structure
  */
 IDLValue *idl_value_with_opt(IDLValue *value);
@@ -873,15 +873,23 @@ struct CIDLValuesVec *vec_from_idl_value(const IDLValue *ptr);
  * @param keys Pointer to array of keys
  * @param keys_len Number of Keys
  * @param vals Pointer to array of IDLValues
- * @param vals_len Number of Values, take in account rust will take
+ * @param vals_len Number of Values
+ * @param keys_are_ids If set to true, keys are expected to be [u8; 4] and will
+ * be read as LE u32 and the resulting record will have unnamed/id labels based
+ * on the value of the keys
+ *
+ * Take in account rust will take
  * ownership of the memory where this array is stored and free it once it comes out of
- * the function scope. So the user should not use this array after calling
+ * the function scope.
+ * So the user should not use this array after calling this function
+ *
  * @return Pointer to IDLValue Structure
  */
 IDLValue *idl_value_with_record(const char *const *keys,
                                 int keys_len,
                                 const IDLValue *const *vals,
-                                int vals_len);
+                                int vals_len,
+                                bool keys_are_ids);
 
 /**
  * @brief Get Record from IDLValue

--- a/lib-agent-cpp/inc/func.h
+++ b/lib-agent-cpp/inc/func.h
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#ifndef FUNC_H
+#define FUNC_H
+#include <string>
+
+#include "principal.h"
+
+extern "C" {
+#include "zondax_ic.h"
+}
+
+namespace zondax {
+class Func {
+ private:
+  zondax::Principal princ;
+  std::string method;
+
+ public:
+  // Disable copies, just move semantics
+  Func(const Func &args) = delete;
+  void operator=(const Func &) = delete;
+
+  /**
+   * @brief Move constructor for Func objects.
+   *
+   * @param o The Func object to move.
+   *
+   * This constructor moves the content of the provided Func object into a
+   * new Func object.
+   */
+  Func(Func &&o) noexcept;
+
+  /**
+   * @brief Move assignment operator for Func objects.
+   *
+   * @param o The Func object to move.
+   *
+   * This operator moves the content of the provided Func object into an
+   * existing Func object.
+   */
+  Func &operator=(Func &&o) noexcept;
+
+  /**
+   * @brief Constructs a service by taking ownership of the passed principal
+   * obj.
+   *
+   * @param principal The Principal object to move.
+   *
+   * This operator moves the content of the provided Principal object and string
+   * into an a new Func object.
+   */
+  explicit Func(zondax::Principal &&principal,
+                std::string &&method_name) noexcept;
+
+  /**
+   * @brief Borrow the inner principal object.
+   *
+   * @return Reference to the Principal instance.
+   */
+  const zondax::Principal &principal() const;
+
+  /**
+   * @brief Borrow the inner method name.
+   *
+   * @return Reference to the method name.
+   */
+  const std::string &method_name() const;
+
+  /**
+   * @brief Take out the principal obj.
+   *
+   * @return The Principal instance.
+   */
+  zondax::Principal principal_take() noexcept;
+
+  ~Func();
+};
+}  // namespace zondax
+#endif  // FUNC_H

--- a/lib-agent-cpp/inc/idl_args.h
+++ b/lib-agent-cpp/inc/idl_args.h
@@ -27,10 +27,19 @@ extern "C" {
 #include "zondax_ic.h"
 }
 
+namespace std {
+template <>
+struct default_delete<IDLArgs> {
+  void operator()(IDLArgs *ptr) const {
+    if (ptr != nullptr) idl_args_destroy(ptr);
+  }
+};
+}  // namespace std
+
 namespace zondax {
 class IdlArgs {
  private:
-  IDLArgs *ptr;
+  std::unique_ptr<IDLArgs> ptr;
 
  public:
   // Disable copies, just move semantics
@@ -53,11 +62,7 @@ class IdlArgs {
   std::vector<uint8_t> getBytes();
   std::vector<zondax::IdlValue> getVec();
 
-  // why C++ users would want to have a pointer to an opque type?
-  // it is meant to be use by us?
-  IDLArgs *getPtr() const;
-
-  ~IdlArgs();
+  std::unique_ptr<IDLArgs> getPtr();
 };
 }  // namespace zondax
 

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <iostream>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 #include "idl_value_utils.h"
@@ -66,16 +67,22 @@ class IdlValue {
   // Templated IdlValues constructors
   template <typename T>
   explicit IdlValue(T);
-  template <typename T>
+  template <typename T,
+            typename = std::enable_if_t<std::is_constructible_v<IdlValue, T>>>
   explicit IdlValue(std::optional<T>);
 
-  template <typename T>
+  template <typename T,
+            typename = std::enable_if_t<std::is_constructible_v<IdlValue, T>>>
   explicit IdlValue(const std::vector<T> &);
 
-  template <typename... Args>
+  template <typename... Args,
+            typename = std::enable_if_t<
+                (std::is_constructible_v<IdlValue, Args> && ...)>>
   explicit IdlValue(const std::tuple<Args...> &);
 
-  template <typename... Args>
+  template <typename... Args,
+            typename = std::enable_if_t<
+                (std::is_constructible_v<IdlValue, Args> && ...)>>
   explicit IdlValue(const std::variant<Args...> &);
 
   // Specific constructors

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -94,8 +94,7 @@ class IdlValue {
   static IdlValue null();
   static IdlValue reserved();
 
-  static IdlValue FromRecord(const std::vector<std::string> &keys,
-                             const std::vector<IdlValue *> &elems);
+  static IdlValue FromRecord(std::vector<std::pair<std::string, IdlValue>> &);
   static IdlValue FromVariant(std::string key, IdlValue *val, uint64_t code);
   static IdlValue FromFunc(std::vector<uint8_t> vector, std::string func_name);
 

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -48,6 +48,11 @@ class IdlValue {
   // errors by reset value to nullptr
   void resetValue();
 
+  // Helper to initialize .ptr from an std::tuple-like set of items
+  // used by IdlValue(std::tuple<Args...>) constructor
+  template <typename Tuple, size_t... Indices>
+  void initializeFromTuple(const Tuple &tuple, std::index_sequence<Indices...>);
+
  public:
   // Disable copies, just move semantics
   IdlValue(const IdlValue &args) = delete;
@@ -58,29 +63,30 @@ class IdlValue {
   // declare move assignment
   IdlValue &operator=(IdlValue &&o) noexcept;
 
-  // Create IdlValues from types
-  IdlValue(IDLValue *ptr);
-  IdlValue();
-  explicit IdlValue(uint8_t val);
-  explicit IdlValue(uint16_t val);
-  explicit IdlValue(uint32_t val);
-  explicit IdlValue(uint64_t val);
-  explicit IdlValue(int8_t val);
-  explicit IdlValue(int16_t val);
-  explicit IdlValue(int32_t val);
-  explicit IdlValue(int64_t val);
-  explicit IdlValue(float val);
-  explicit IdlValue(double val);
-  explicit IdlValue(bool val);
-  explicit IdlValue(std::string text);
-  explicit IdlValue(zondax::Principal principal,
-                    bool type = true);  // true create principal false: service
-  IdlValue FromNull(void);
-  IdlValue FromNone(void);
-  IdlValue FromReserved(void);
-  IdlValue FromNumber(std::string number);
-  IdlValue FromOpt(IdlValue *value);
-  IdlValue FromVec(const std::vector<const IdlValue *> &elems);
+  // Templated IdlValues constructors
+  template <typename T>
+  explicit IdlValue(T);
+  template <typename T>
+  explicit IdlValue(std::optional<T>);
+
+  template <typename T>
+  explicit IdlValue(const std::vector<T> &);
+
+  template <typename... Args>
+  explicit IdlValue(const std::tuple<Args...> &);
+
+  template <typename... Args>
+  explicit IdlValue(const std::variant<Args...> &);
+
+  // Specific constructors
+  explicit IdlValue() : ptr(nullptr) {}
+  explicit IdlValue(zondax::Principal,
+                    bool = true);  // true create principal false: service
+
+  static IdlValue null();
+  static IdlValue reserved();
+  static IdlValue BigNum(std::string number);
+
   IdlValue FromRecord(const std::vector<std::string> &keys,
                       const std::vector<const IdlValue *> &elems);
   IdlValue FromVariant(std::string key, IdlValue *val, uint64_t code);

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -90,8 +90,6 @@ class IdlValue {
 
   // Specific constructors
   explicit IdlValue() : ptr(nullptr) {}
-  explicit IdlValue(zondax::Principal,
-                    bool = true);  // true create principal false: service
 
   static IdlValue null();
   static IdlValue reserved();

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -59,12 +59,13 @@ class IdlValue {
   IdlValue(const IdlValue &args) = delete;
   void operator=(const IdlValue &) = delete;
 
-  // declare move constructor
+  // declare move constructor & assignment
   IdlValue(IdlValue &&o) noexcept;
-  // declare move assignment
   IdlValue &operator=(IdlValue &&o) noexcept;
 
-  // Templated IdlValues constructors
+  ~IdlValue();
+
+  /******************** Constructors ***********************/
   template <typename T>
   explicit IdlValue(T);
   template <typename T,
@@ -98,7 +99,7 @@ class IdlValue {
   IdlValue FromVariant(std::string key, IdlValue *val, uint64_t code);
   IdlValue FromFunc(std::vector<uint8_t> vector, std::string func_name);
 
-  // Get types
+  /******************** Getters ***********************/
   template <typename T>
   std::optional<T> get();
 
@@ -111,8 +112,6 @@ class IdlValue {
   // the first will aliase pointer, breaking move semantics only
   // for this type if used wrong.
   IDLValue *getPtr() const;
-
-  ~IdlValue();
 };
 }  // namespace zondax
 

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -25,8 +25,6 @@
 #include <vector>
 
 #include "idl_value_utils.h"
-#include "principal.h"
-#include "service.h"
 
 extern "C" {
 #include "zondax_ic.h"

--- a/lib-agent-cpp/inc/idl_value.h
+++ b/lib-agent-cpp/inc/idl_value.h
@@ -92,7 +92,6 @@ class IdlValue {
 
   static IdlValue null();
   static IdlValue reserved();
-  static IdlValue BigNum(std::string number);
 
   IdlValue FromRecord(const std::vector<std::string> &keys,
                       const std::vector<const IdlValue *> &elems);
@@ -103,7 +102,6 @@ class IdlValue {
   template <typename T>
   std::optional<T> get();
 
-  std::optional<zondax::Principal> getService();
   std::optional<IdlValue> getOpt();
   std::vector<IdlValue> getVec();
   // zondax::idl_value_utils::Record getRecord();

--- a/lib-agent-cpp/inc/idl_value_utils.h
+++ b/lib-agent-cpp/inc/idl_value_utils.h
@@ -28,11 +28,6 @@ namespace zondax {
 
 class IdlValue;
 
-struct Func {
-  std::string s;
-  zondax::Principal p;
-};
-
 struct Record {
   std::vector<std::string> keys;
   std::vector<std::unique_ptr<IdlValue *>> vals;

--- a/lib-agent-cpp/src/func.cpp
+++ b/lib-agent-cpp/src/func.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *   (c) 2018 - 2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#include "func.h"
+
+#include <cstdlib>
+#include <optional>
+
+namespace zondax {
+
+// declare move constructor
+Func::Func(Func &&o) noexcept
+    : princ(std::move(o.princ)), method(std::move(o.method)) {}
+
+// declare move assignment
+Func &Func::operator=(Func &&o) noexcept {
+  // check they are not the same object
+  if (&o == this) return *this;
+
+  princ = std::move(o.princ);
+  method = std::move(o.method);
+
+  return *this;
+}
+
+Func::Func(zondax::Principal &&p, std::string &&m) noexcept
+    : princ(std::move(p)), method(std::move(m)) {}
+
+// zondax::Principal &Service::principal() noexcept { return principal; }
+const zondax::Principal &Func::principal() const { return princ; }
+const std::string &Func::method_name() const { return method; }
+
+zondax::Principal Func::principal_take() noexcept { return std::move(princ); }
+
+}  // namespace zondax

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -183,17 +183,23 @@ IdlValue::IdlValue(const std::variant<Args...> &variant) {
 template <>
 IdlValue::IdlValue(IDLValue *ptr) : ptr(ptr){};
 
-IdlValue::IdlValue(zondax::Principal principal, bool is_principal) {
+template <>
+IdlValue::IdlValue(zondax::Principal principal) {
   // TODO: Use RetError
   // RetPtr_u8 error;
 
-  auto p = is_principal
-               ? idl_value_with_principal(principal.getBytes().data(),
-                                          principal.getBytes().size(), nullptr)
-               : idl_value_with_service(principal.getBytes().data(),
-                                        principal.getBytes().size(), nullptr);
+  ptr.reset(idl_value_with_principal(principal.getBytes().data(),
+                                     principal.getBytes().size(), nullptr));
+}
 
-  ptr.reset(p);
+template <>
+IdlValue::IdlValue(zondax::Service service) {
+  // TODO: Use RetError
+  // RetPtr_u8 error;
+
+  auto principal = service.principal_take();
+  ptr.reset(idl_value_with_service(principal.getBytes().data(),
+                                   principal.getBytes().size(), nullptr));
 }
 
 IdlValue IdlValue::null(void) {

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -20,6 +20,10 @@
 #include <optional>
 #include <variant>
 
+#include "func.h"
+#include "idl_value_utils.h"
+#include "service.h"
+
 namespace zondax {
 
 #define PRIMITIVE_TYPES_GETTER(name, type)               \
@@ -209,6 +213,14 @@ IdlValue::IdlValue(zondax::Service service) {
                                    principal.getBytes().size(), nullptr));
 }
 
+template <>
+IdlValue::IdlValue(zondax::Func func) {
+  auto princ = func.principal().getBytes();
+
+  ptr.reset(idl_value_with_func(princ.data(), princ.size(),
+                                func.method_name().c_str()));
+}
+
 IdlValue IdlValue::null(void) {
   IdlValue val;
   val.ptr.reset(idl_value_with_null());
@@ -220,8 +232,6 @@ IdlValue IdlValue::reserved(void) {
   val.ptr.reset(idl_value_with_reserved());
   return val;
 }
-
-// TODO: improve the constructors below
 
 IdlValue IdlValue::FromRecord(
     std::vector<std::pair<std::string, IdlValue>> &fields) {
@@ -240,14 +250,10 @@ IdlValue IdlValue::FromRecord(
   return IdlValue(p);
 }
 
+// TODO: improve the constructors below
+
 IdlValue IdlValue::FromVariant(std::string key, IdlValue *val, uint64_t code) {
   auto p = idl_value_with_variant(key.c_str(), val->ptr.release(), code);
-  return IdlValue(p);
-}
-
-IdlValue IdlValue::FromFunc(std::vector<uint8_t> vector,
-                            std::string func_name) {
-  auto p = idl_value_with_func(vector.data(), vector.size(), func_name.c_str());
   return IdlValue(p);
 }
 

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -189,13 +189,12 @@ IdlValue IdlValue::reserved(void) {
   return val;
 }
 
-IdlValue IdlValue::BigNum(std::string number) {
+template <>
+IdlValue::IdlValue(Number number) {
   // TODO: Use RetError
   // RetPtr_u8 error;
-  IdlValue val;
 
-  val.ptr = idl_value_with_number(number.c_str(), nullptr);
-  return val;
+  ptr = idl_value_with_number(number.value.c_str(), nullptr);
 }
 
 template <typename T, typename>

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -223,18 +223,16 @@ IdlValue IdlValue::reserved(void) {
 
 // TODO: improve the constructors below
 
-IdlValue IdlValue::FromRecord(const std::vector<std::string> &keys,
-                              const std::vector<IdlValue *> &elems) {
-  std::vector<const IDLValue *> cElems;
-  cElems.reserve(elems.size());
-  for (IdlValue *elem : elems) {
-    cElems.push_back(elem->ptr.release());
-  }
-
+IdlValue IdlValue::FromRecord(
+    std::vector<std::pair<std::string, IdlValue>> &fields) {
   std::vector<const char *> cKeys;
-  cKeys.reserve(keys.size());
-  for (const std::string &key : keys) {
+  cKeys.reserve(fields.size());
+  std::vector<const IDLValue *> cElems;
+  cElems.reserve(fields.size());
+
+  for (auto &[key, value] : fields) {
     cKeys.push_back(key.c_str());
+    cElems.push_back(value.ptr.release());
   }
 
   auto p = idl_value_with_record(cKeys.data(), cKeys.size(), cElems.data(),

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -130,7 +130,7 @@ IdlValue::IdlValue(zondax::Principal principal, bool is_principal) {
                                      principal.getBytes().size(), nullptr);
 }
 
-template <typename T>
+template <typename T, typename>
 IdlValue::IdlValue(std::optional<T> val) {
   if (val.has_value()) {
     *this = IdlValue(val.value());
@@ -167,12 +167,12 @@ void IdlValue::initializeFromTuple(const Tuple &tuple,
                               values.size());
 }
 
-template <typename... Args>
+template <typename... Args, typename>
 IdlValue::IdlValue(const std::tuple<Args...> &tuple) {
   initializeFromTuple(tuple, std::index_sequence_for<Args...>());
 }
 
-template <typename... Args>
+template <typename... Args, typename>
 IdlValue::IdlValue(const std::variant<Args...> &variant) {
   std::visit([this](const auto &value) { *this = IdlValue(value); }, variant);
 }
@@ -198,7 +198,7 @@ IdlValue IdlValue::BigNum(std::string number) {
   return val;
 }
 
-template <typename T>
+template <typename T, typename>
 IdlValue::IdlValue(const std::vector<T> &elems) {
   std::vector<const IDLValue *> cElems;
   cElems.reserve(elems.size());


### PR DESCRIPTION
This allows the class to be slimmed but most especially allows us to specialize the constructor for any type, making it easier to convert between a given `T` from the generated type declarations to be used in actual code.

Inclusions:
* `T`
* `std::optional<T>`
* `std::vector<T>`
* `std::tuple<T...>` (Note: depends on #19)

WIP:
* [ ] `std::variant<T...>`(Incomplete: generated variants don't maintain fields names, required for this)
* [x] Records (Note: to be improved by #17) 

<!-- ClickUpRef: 861n06qj5 -->
:link: [zboto Link](https://app.clickup.com/t/861n06qj5)