### PR TITLE
Fix/specializations

### DIFF
--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -246,6 +246,31 @@ TEST_CASE("IdlValue from/to tuple") {
   REQUIRE(bytes[0] == 0x01);
 }
 
+TEST_CASE("IdlValue from/to vector<std::tuple<Args...>>") {
+  // construct tuple
+  std::vector<std::tuple<uint8_t, uint64_t, double, std::string, bool>> vec;
+  for (int i = 0; i < 10; ++i) {
+    std::tuple<uint8_t, uint64_t, double, std::string, bool> tuple =
+        std::make_tuple((uint8_t)i, 100500, 2.5, std::string("zondax"),
+                        (i % 2 == 0));
+    vec.push_back(tuple);
+  }
+
+  auto copy = vec;
+
+  IdlValue value(std::move(vec));
+
+  auto back = value.get<
+      std::vector<std::tuple<uint8_t, uint64_t, double, std::string, bool>>>();
+
+  REQUIRE(back.has_value());
+  auto vec2 = back.value();
+  REQUIRE(copy.size() == vec2.size());
+  auto equal = copy == vec2;
+  // REQUIRE(true == equal);
+  REQUIRE(copy == vec2);
+}
+
 struct Peer_authentication {
   explicit Peer_authentication() = default;
   static constexpr std::string_view __CANDID_VARIANT_NAME{"authentication"};

--- a/lib-agent-cpp/src/idl_value.cpp
+++ b/lib-agent-cpp/src/idl_value.cpp
@@ -29,38 +29,7 @@
 
 namespace zondax {
 
-#define PRIMITIVE_TYPES_GETTER(name, type)                                  \
-  template <>                                                               \
-  std::optional<type> zondax::IdlValue::getImpl(helper::tag_type<type> t) { \
-    if (ptr == nullptr) return std::nullopt;                                \
-    type value;                                                             \
-    bool ret = name##_from_idl_value(ptr.get(), &value);                    \
-    if (!ret) return std::nullopt;                                          \
-    return std::make_optional<type>(value);                                 \
-  }
-
-#define VEC_PRIMITIVE_TYPES_GETTER(type)                                     \
-  template <>                                                                \
-  std::optional<std::vector<type>> zondax::IdlValue::getImpl(                \
-      helper::tag_type<std::vector<type>> t) {                               \
-    auto values_vec = vec_from_idl_value(ptr.get());                         \
-    if (values_vec == nullptr) return std::nullopt;                          \
-    auto vec_len = cidlval_vec_len(values_vec);                              \
-    std::vector<type> ret;                                                   \
-    for (int i = 0; i < vec_len; ++i) {                                      \
-      auto p = cidlval_vec_value_take(values_vec, i);                        \
-      if (p == nullptr) return std::nullopt;                                 \
-      IdlValue value(p);                                                     \
-      std::optional<type> val = value.get<type>();                           \
-      if (!val.has_value()) return std::nullopt;                             \
-      ret.emplace_back(std::move(val.value()));                              \
-    }                                                                        \
-    /*we took ownership of inner fields but still needs to destroy vector */ \
-    cidlval_vec_destroy(values_vec);                                         \
-    return std::make_optional<std::vector<type>>(std::move(ret));            \
-  }                                                                          \
-                                                                             \
-  /******************** Public ***********************/
+/******************** Public ***********************/
 
 IdlValue::IdlValue(IdlValue &&o) noexcept : ptr(std::move(o.ptr)) {}
 
@@ -73,164 +42,6 @@ IdlValue &IdlValue::operator=(IdlValue &&o) noexcept {
 }
 
 /******************** T -> IdlValue ***********************/
-
-template <>
-IdlValue::IdlValue(uint8_t value) {
-  ptr.reset(idl_value_with_nat8(value));
-}
-
-template <>
-IdlValue::IdlValue(uint16_t value) {
-  ptr.reset(idl_value_with_nat16(value));
-}
-
-template <>
-IdlValue::IdlValue(uint32_t value) {
-  ptr.reset(idl_value_with_nat32(value));
-}
-
-template <>
-IdlValue::IdlValue(uint64_t value) {
-  ptr.reset(idl_value_with_nat64(value));
-}
-
-template <>
-IdlValue::IdlValue(int8_t value) {
-  ptr.reset(idl_value_with_int8(value));
-}
-
-template <>
-IdlValue::IdlValue(int16_t value) {
-  ptr.reset(idl_value_with_int16(value));
-}
-
-template <>
-IdlValue::IdlValue(int32_t value) {
-  ptr.reset(idl_value_with_int32(value));
-}
-
-template <>
-IdlValue::IdlValue(int64_t value) {
-  ptr.reset(idl_value_with_int64(value));
-}
-
-template <>
-IdlValue::IdlValue(float value) {
-  ptr.reset(idl_value_with_float32(value));
-}
-
-template <>
-IdlValue::IdlValue(double value) {
-  ptr.reset(idl_value_with_float64(value));
-}
-
-template <>
-IdlValue::IdlValue(bool value) {
-  ptr.reset(idl_value_with_bool(value));
-}
-
-template <>
-IdlValue::IdlValue(std::string text) {
-  // TODO: Use RetError
-  ptr.reset(idl_value_with_text(text.c_str(), nullptr));
-}
-
-template <>
-IdlValue::IdlValue(Number number) {
-  // TODO: Use RetError
-  // RetPtr_u8 error;
-
-  ptr.reset(idl_value_with_number(number.value.c_str(), nullptr));
-}
-
-template <typename T, typename>
-IdlValue::IdlValue(std::optional<T> val) {
-  if (val.has_value()) {
-    auto value = IdlValue(val.value());
-    ptr.reset(idl_value_with_opt(value.ptr.release()));
-  } else {
-    ptr.reset(idl_value_with_none());
-  }
-}
-
-template <typename T, typename>
-IdlValue::IdlValue(const std::vector<T> &elems) {
-  std::vector<const IDLValue *> cElems;
-  cElems.reserve(elems.size());
-
-  for (auto e : elems) {
-    IdlValue val(e);
-    cElems.push_back(val.ptr.release());
-  }
-
-  ptr.reset(idl_value_with_vec(cElems.data(), cElems.size()));
-}
-
-template <typename... Args, typename>
-IdlValue::IdlValue(std::tuple<Args...> &tuple) {
-  initializeFromTuple(tuple, std::index_sequence_for<Args...>());
-}
-
-template <typename... Args, typename, typename>
-IdlValue::IdlValue(const std::variant<Args...> &variant) {
-  std::visit(
-      [this](auto &value) {
-        IdlValue val(std::move(value));
-        *this = IdlValue::FromVariant(std::string(value.__CANDID_VARIANT_NAME),
-                                      &val, value.__CANDID_VARIANT_CODE);
-      },
-      variant);
-}
-
-template <>
-IdlValue::IdlValue(IDLValue *ptr) : ptr(ptr){};
-
-template <>
-IdlValue::IdlValue(const IDLValue *ptr) : ptr((IDLValue *)ptr){};
-
-template <>
-IdlValue::IdlValue(zondax::Principal principal) {
-  // TODO: Use RetError
-  // RetPtr_u8 error;
-
-  ptr.reset(idl_value_with_principal(principal.getBytes().data(),
-                                     principal.getBytes().size(), nullptr));
-}
-
-template <>
-IdlValue::IdlValue(zondax::Service service) {
-  // TODO: Use RetError
-  // RetPtr_u8 error;
-
-  auto principal = service.principal_take();
-  ptr.reset(idl_value_with_service(principal.getBytes().data(),
-                                   principal.getBytes().size(), nullptr));
-}
-
-template <>
-IdlValue::IdlValue(zondax::Func func) {
-  auto princ = func.principal().getBytes();
-
-  ptr.reset(idl_value_with_func(princ.data(), princ.size(),
-                                func.method_name().c_str()));
-}
-
-template <>
-IdlValue::IdlValue(std::monostate) {
-  ptr.reset(idl_value_with_null());
-}
-
-IdlValue IdlValue::null(void) {
-  IdlValue val;
-  val.ptr.reset(idl_value_with_null());
-  return val;
-}
-
-IdlValue IdlValue::reserved(void) {
-  IdlValue val;
-  val.ptr.reset(idl_value_with_reserved());
-  return val;
-}
 
 IdlValue IdlValue::FromRecord(
     std::unordered_map<std::string, IdlValue> &fields) {
@@ -258,152 +69,6 @@ IdlValue IdlValue::FromVariant(std::string key, IdlValue *val, uint64_t code) {
 
 // ---------------------- IdlValue::get() specializations ---
 
-PRIMITIVE_TYPES_GETTER(int8, int8_t)
-PRIMITIVE_TYPES_GETTER(int16, int16_t)
-PRIMITIVE_TYPES_GETTER(int32, int32_t)
-PRIMITIVE_TYPES_GETTER(int64, int64_t)
-PRIMITIVE_TYPES_GETTER(nat8, uint8_t)
-PRIMITIVE_TYPES_GETTER(nat16, uint16_t)
-PRIMITIVE_TYPES_GETTER(nat32, uint32_t)
-PRIMITIVE_TYPES_GETTER(nat64, uint64_t)
-PRIMITIVE_TYPES_GETTER(float32, float)
-PRIMITIVE_TYPES_GETTER(float64, double)
-PRIMITIVE_TYPES_GETTER(bool, bool)
-
-template <>
-std::optional<std::string> IdlValue::getImpl(
-    helper::tag_type<std::string> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  CText *ctext = text_from_idl_value(ptr.get());
-  if (ctext == nullptr) return std::nullopt;
-
-  const char *str = ctext_str(ctext);
-  if (str == nullptr) return std::nullopt;
-
-  // use c null-terminated string constructor
-  std::string s(str);
-
-  ctext_destroy(ctext);
-
-  return std::make_optional<std::string>(s);
-}
-
-template <>
-std::optional<zondax::Principal> IdlValue::getImpl(
-    helper::tag_type<zondax::Principal> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  CPrincipal *p = principal_from_idl_value(ptr.get());
-  if (p == nullptr) return std::nullopt;
-
-  std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
-  zondax::Principal principal(bytes);
-
-  principal_destroy(p);
-
-  return std::make_optional(std::move(principal));
-}
-
-template <>
-std::optional<Number> IdlValue::getImpl(helper::tag_type<Number> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  CText *ctext = number_from_idl_value(ptr.get());
-  if (ctext == nullptr) return std::nullopt;
-
-  const char *str = ctext_str(ctext);
-
-  std::string text(str);
-
-  ctext_destroy(ctext);
-  Number number;
-  number.value = text;
-
-  return std::make_optional(number);
-}
-
-template <>
-std::optional<zondax::Func> IdlValue::getImpl(helper::tag_type<Func> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  struct CFunc *cFunc = func_from_idl_value(ptr.get());
-  if (cFunc == nullptr) return std::nullopt;
-
-  // Extract principal
-  struct CPrincipal *cPrincipal = cfunc_principal(cFunc);
-  std::vector<uint8_t> vec =
-      std::vector<uint8_t>(cPrincipal->ptr, cPrincipal->ptr + cPrincipal->len);
-
-  zondax::Func result(
-      zondax::Principal(vec),
-      std::string(cfunc_string(cFunc),
-                  cfunc_string(cFunc) + cfunc_string_len(cFunc)));
-
-  // Free the allocated CFunc
-  cfunc_destroy(cFunc);
-
-  return std::optional<zondax::Func>(std::move(result));
-}
-
-template <>
-std::optional<std::vector<IdlValue>> IdlValue::getImpl(
-    helper::tag_type<std::vector<IdlValue>> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  // call bellow creates a new IDLValue::Vec,
-  // this means it "clones" from this.ptr
-  struct CIDLValuesVec *cVec = vec_from_idl_value(ptr.get());
-  if (cVec == nullptr) return std::nullopt;
-
-  uintptr_t length = cidlval_vec_len(cVec);
-
-  std::vector<IdlValue> result;
-  result.reserve(length);
-
-  // then it should take out each value from the vector
-  // and give ownership to the caller.
-  for (uintptr_t i = 0; i < length; ++i) {
-    // the take variant leave the value in the vector in a null state
-    // this is valid as inner value belongs now to result
-    const IDLValue *valuePtr = cidlval_vec_value_take(cVec, i);
-    result.emplace_back(valuePtr);
-  }
-
-  // Free the allocated CIDLValuesVec
-  cidlval_vec_destroy(cVec);
-
-  return std::make_optional(std::move(result));
-}
-
-template <>
-std::optional<zondax::Service> IdlValue::getImpl(
-    helper::tag_type<zondax::Service> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  CPrincipal *p = service_from_idl_value(ptr.get());
-
-  if (p == nullptr) return std::nullopt;
-
-  std::vector<unsigned char> bytes(p->ptr, p->ptr + p->len);
-  zondax::Principal principal(bytes);
-
-  // there is not issue in destroying raw principal
-  // because bytes makes a deep copy
-  principal_destroy(p);
-
-  return std::make_optional(zondax::Service(std::move(principal)));
-}
-
-template <>
-std::optional<std::monostate> IdlValue::getImpl(
-    helper::tag_type<std::monostate> type) {
-  if (ptr == nullptr) return std::nullopt;
-
-  return idl_value_is_null(ptr.get()) ? std::make_optional<std::monostate>()
-                                      : std::nullopt;
-}
-
 std::optional<IdlValue> IdlValue::getOpt() {
   if (ptr == nullptr) return std::nullopt;
 
@@ -413,61 +78,6 @@ std::optional<IdlValue> IdlValue::getOpt() {
 
   return IdlValue(result);
 }
-
-// Record specialization
-// TODO: We need to add testing for this!!!!!
-template <>
-std::optional<std::unordered_map<std::string, IdlValue>>
-IdlValue::getImpl<std::unordered_map<std::string, IdlValue>>(
-    helper::tag_type<std::unordered_map<std::string, IdlValue>> t) {
-  if (ptr.get() == nullptr) return std::nullopt;
-  auto record = record_from_idl_value(ptr.get());
-  if (record == nullptr) return std::nullopt;
-
-  std::unordered_map<std::string, IdlValue> fields;
-
-  auto len = crecord_keys_len(record);
-
-  for (uintptr_t i = 0; i < len; ++i) {
-    auto cKey = crecord_take_key(record, i);
-    auto cVal = crecord_take_val(record, i);
-
-    if (cKey == nullptr || cVal == nullptr) return std::nullopt;
-
-    auto str = ctext_str(cKey);
-    if (str == nullptr) return std::nullopt;
-
-    auto key = std::string("");
-    if (str != nullptr) {
-      key = std::string(str);
-    }
-
-    IdlValue val(cVal);
-
-    fields.emplace(std::make_pair(key, std::move(val)));
-  }
-
-  // crecord_destroy(record);
-
-  return std::make_optional(std::move(fields));
-}
-
-VEC_PRIMITIVE_TYPES_GETTER(int8_t)
-VEC_PRIMITIVE_TYPES_GETTER(int16_t)
-VEC_PRIMITIVE_TYPES_GETTER(int32_t)
-VEC_PRIMITIVE_TYPES_GETTER(int64_t)
-VEC_PRIMITIVE_TYPES_GETTER(uint8_t)
-VEC_PRIMITIVE_TYPES_GETTER(uint16_t)
-VEC_PRIMITIVE_TYPES_GETTER(uint32_t)
-VEC_PRIMITIVE_TYPES_GETTER(uint64_t)
-VEC_PRIMITIVE_TYPES_GETTER(float)
-VEC_PRIMITIVE_TYPES_GETTER(double)
-VEC_PRIMITIVE_TYPES_GETTER(bool)
-VEC_PRIMITIVE_TYPES_GETTER(std::string)
-VEC_PRIMITIVE_TYPES_GETTER(zondax::Principal)
-VEC_PRIMITIVE_TYPES_GETTER(zondax::Func)
-VEC_PRIMITIVE_TYPES_GETTER(zondax::Service)
-VEC_PRIMITIVE_TYPES_GETTER(std::monostate)
 
 std::optional<std::tuple<std::string, std::size_t, IdlValue>>
 IdlValue::asCVariant() {
@@ -523,6 +133,7 @@ std::unordered_map<std::string, IdlValue> IdlValue::getRecord() {
 }
 
 std::unique_ptr<IDLValue> IdlValue::getPtr() { return std::move(ptr); }
+
 }  // namespace zondax
 
 // ------------------------------------------------- TESTS
@@ -562,47 +173,20 @@ TEST_CASE("IdlValue from/to string") {
 TEST_CASE("IdlValue from/to Vec<string>") {
   std::string str("Zondax");
   std::vector<std::string> vec{str, str, str, str, str};
+  auto copy = vec;
 
-  IdlValue value(vec);
+  IdlValue value(std::move(vec));
   auto back = value.get<std::vector<std::string>>();
   REQUIRE(back.has_value());
   auto val = back.value();
   REQUIRE(vec.size() == val.size());
-  REQUIRE(std::equal(vec.begin(), vec.end(), std::begin(val)));
-}
-
-// TODO: Uncomment test, currently this does not compile due to constructor
-TEST_CASE("IdlValue from/to std::tuple<std::string, std::string>") {
-  std::string first("first");
-  std::string second("second");
-
-  // construct tuple
-  std::tuple<std::string, std::string> tuple{first, second};
-
-  IdlValue value(tuple);
-
-  // auto back = value.get<std::unordered_map<std::string, IdlValue>>();
-  auto map = value.getRecord();
-
-  REQUIRE(map.size() == 2);
-
-  for (auto &n : map) {
-    auto val = n.second.get<std::string>();
-    REQUIRE(val.has_value());
-    auto str = val.value();
-
-    if (n.first.compare("0") == 0) {
-      REQUIRE(str == first);
-    } else if (n.first.compare("1") == 0) {
-      REQUIRE(str == second);
-    }
-  }
+  REQUIRE(std::equal(copy.begin(), copy.end(), std::begin(val)));
 }
 
 TEST_CASE_TEMPLATE_DEFINE("IdlValue from/to vector of ints", T,
                           test_id_vector) {
   std::vector<T> val{1, 2, 4, 5};
-  IdlValue value(val);
+  IdlValue value(std::move(val));
   auto back = value.get<std::vector<T>>();
 
   REQUIRE(back.has_value());
@@ -610,7 +194,8 @@ TEST_CASE_TEMPLATE_DEFINE("IdlValue from/to vector of ints", T,
   REQUIRE(vec.size() == val.size());
   REQUIRE(std::equal(vec.begin(), vec.end(), std::begin(val)));
 
-  // check that it fails if comparing with another vector with different values
+  // check that it fails if comparing with another vector with different
+  // values
   std::vector<T> val2{6, 7, 8, 9};
   REQUIRE(!std::equal(vec.begin(), vec.end(), std::begin(val2)));
 }
@@ -621,7 +206,7 @@ TEST_CASE_TEMPLATE_INVOKE(test_id_vector, uint8_t, uint16_t, uint32_t, uint64_t,
 TEST_CASE_TEMPLATE_DEFINE("IdlValue from/to vector of floats", T,
                           test_id_vector_floats) {
   std::vector<T> val{1.0, 2.04, 4.555, 5.89};
-  IdlValue value(val);
+  IdlValue value(std::move(val));
   auto back = value.get<std::vector<T>>();
 
   REQUIRE(back.has_value());
@@ -632,21 +217,33 @@ TEST_CASE_TEMPLATE_DEFINE("IdlValue from/to vector of floats", T,
 TEST_CASE_TEMPLATE_INVOKE(test_id_vector_floats, float, double);
 
 TEST_CASE("IdlValue from/to tuple") {
-  std::tuple<uint32_t, std::string, float> tuple1{1000, std::string("tuple"),
-                                                  25.5};
-  // make a copy because in constructor impl, we move values
-  auto copy = tuple1;
-  IdlValue value(copy);
+  // Get Principal from slice of bytes
+  std::vector<uint8_t> slice = {0x1};
 
-  auto back = value.get<std::tuple<uint32_t, std::string, float>>();
+  zondax::Principal principal(slice);
+  // construct tuple
+  std::tuple<uint8_t, uint64_t, double, std::string, zondax::Principal> tuple =
+      std::make_tuple(1, 100500, 2.5, std::string("zondax"),
+                      std::move(principal));
 
+  IdlValue value(std::move(tuple));
+
+  auto back = value.get<
+      std::tuple<uint8_t, uint64_t, double, std::string, zondax::Principal>>();
   REQUIRE(back.has_value());
 
-  auto tuple2 = back.value();
+  auto tuple2 = std::move(back.value());
 
-  REQUIRE(std::get<0>(tuple2) == std::get<0>(tuple1));
-  REQUIRE(std::get<1>(tuple2) == std::get<1>(tuple1));
-  REQUIRE(std::get<2>(tuple2) == std::get<2>(tuple1));
+  REQUIRE(1 == std::get<0>(tuple2));
+  REQUIRE(100500 == std::get<1>(tuple2));
+  REQUIRE(2.5 == std::get<2>(tuple2));
+  REQUIRE(std::string("zondax") == std::get<3>(tuple2));
+
+  auto p = std::move(std::get<4>(tuple2));
+  auto bytes = p.getBytes();
+
+  REQUIRE(bytes.size() == 1);
+  REQUIRE(bytes[0] == 0x01);
 }
 
 struct Peer_authentication {
@@ -669,7 +266,7 @@ IdlValue::IdlValue(Peer_authentication peer) {
 
   {
     auto name = std::string("value");
-    auto val = IdlValue(std::move(peer.value));
+    auto val = IdlValue(peer.value);
     fields.emplace(std::make_pair(name, std::move(val)));
   }
 
@@ -682,7 +279,7 @@ IdlValue::IdlValue(Sender_report sender) {
 
   {
     auto name = std::string("report");
-    auto val = IdlValue(std::move(sender.report));
+    auto val = IdlValue(sender.report);
     fields.emplace(std::make_pair(name, std::move(val)));
   }
 


### PR DESCRIPTION
some fixes and new specs, this could help with debugging the current issue "related" template order specialization.
- move template specializations from idl_value.cpp to idl_value.h as required by the compiler, this helped eliminate a bunch of undefined references.
- removed some dead code.
- improve constructors by taking a rvalue, this is only for container types. and update tests accordingly.
- add specialization for get<vec<tuple<Args...>>>() and add a test for it.
- other minor fixes after moving all this to the header, the compiler started complaining.

All these are fixes related to linker errors. 
